### PR TITLE
Crop and Zoom on non 16:9 aspect ratios

### DIFF
--- a/web/screensaver.css
+++ b/web/screensaver.css
@@ -14,6 +14,7 @@
     position: fixed;
     min-width: 100%;
     min-height: 100%;
+    object-fit: cover;
 }
 
 .displayText {


### PR DESCRIPTION
This simple change will crop and zoom the videos on vertical screens, ultrawides, etc. This is the same behavior found on the Mac version of Aerial.

Closes #30 