### PR TITLE
V.1.2.1

### DIFF
--- a/app.js
+++ b/app.js
@@ -1001,10 +1001,11 @@ function lockComputer() {
 
 //idle startup timer
 function launchScreensaver() {
+    let startAfter = store.get('startAfter');
     //console.log(screens.length,powerMonitor.getSystemIdleTime(),store.get('startAfter') * 60)
-    if (screens.length === 0 && !suspend && !isComputerSleeping && !isComputerSuspendedOrLocked) {
+    if (screens.length === 0 && !suspend && !isComputerSleeping && !isComputerSuspendedOrLocked && startAfter > 0) {
         let idleTime = powerMonitor.getSystemIdleTime();
-        if (powerMonitor.getSystemIdleState(store.get('startAfter') * 60) === "idle" && getWakeLock()) {
+        if (powerMonitor.getSystemIdleState(startAfter * 60) === "idle" && getWakeLock()) {
             if (!store.get("runOnBattery")) {
                 if (powerMonitor.isOnBatteryPower()) {
                     return;

--- a/app.js
+++ b/app.js
@@ -330,6 +330,8 @@ app.allowRendererProcessReuse = true
 app.whenReady().then(startUp);
 
 function startUp() {
+    //Uncomment the line below when compiling the .scr file
+    //store.set('useTray', false);
     let firstTime = false;
     if (!store.get("configured") || store.get("version") !== app.getVersion()) {
         firstTime = true;

--- a/app.js
+++ b/app.js
@@ -447,6 +447,7 @@ function setUpConfigFile() {
     store.set('transitionDirection', store.get("transitionDirection") ?? "");
     store.set('videoTransitionLength', store.get('videoTransitionLength') ?? 2000);
     store.set('fillMode', store.get('fillMode') ?? "stretch");
+    store.set('videoFileType', store.get('videoFileType') ?? "H2641080p");
     //1.2.0 changes the default transition length because of internal changes
     if (store.get('videoTransitionLength') === 1000) {
         store.set('videoTransitionLength', 2000);

--- a/app.js
+++ b/app.js
@@ -1004,7 +1004,7 @@ function launchScreensaver() {
     let startAfter = store.get('startAfter');
     //console.log(screens.length,powerMonitor.getSystemIdleTime(),store.get('startAfter') * 60)
     if (screens.length === 0 && !suspend && !isComputerSleeping && !isComputerSuspendedOrLocked && startAfter > 0) {
-        let idleTime = powerMonitor.getSystemIdleTime();
+        //let idleTime = powerMonitor.getSystemIdleTime();
         if (powerMonitor.getSystemIdleState(startAfter * 60) === "idle" && getWakeLock()) {
             if (!store.get("runOnBattery")) {
                 if (powerMonitor.isOnBatteryPower()) {
@@ -1019,19 +1019,30 @@ function launchScreensaver() {
 setInterval(launchScreensaver, 5000);
 
 function onFirstVideoPlayed() {
+    let startTime = new Date();
     setTimeOfDayList();
     if (store.get('blankScreen')) {
-        setTimeout(() => {
-            for (let i = 0; i < screens.length; i++) {
-                screens[i].webContents.send('blankTheScreen');
-                if (store.get('sleepAfterBlank')) {
-                    //sleep the computer after a few seconds of blank screen
-                    setTimeout(() => {
-                        sleepComputer()
-                    }, store.get('videoTransitionLength') * 3)
-                }
+        let interval = setInterval(() => {
+            if (screens.length === 0) {
+                clearTimeout(interval);
+                return;
             }
-        }, store.get('blankAfter') * 60000);
+            if (new Date() - startTime >= store.get('blankAfter') * 60 * 1000) {
+                blankScreensaver();
+            }
+        }, 30000);
+    }
+}
+
+function blankScreensaver() {
+    for (let i = 0; i < screens.length; i++) {
+        screens[i].webContents.send('blankTheScreen');
+        if (store.get('sleepAfterBlank')) {
+            //sleep the computer after a few seconds of blank screen
+            setTimeout(() => {
+                sleepComputer()
+            }, store.get('videoTransitionLength') * 3)
+        }
     }
 }
 

--- a/app.js
+++ b/app.js
@@ -840,9 +840,9 @@ function downloadVideos() {
                     return true;
                 }
             });
-            console.log(allowedVideos[i]);
+            //console.log(allowedVideos[i]);
             //console.log(`Downloading ${videos[index].name}`);
-            downloadFile(videos[index].src.H2641080p, `${cachePath}/temp/${allowedVideos[i]}.mov`, () => {
+            downloadFile(videos[index].src[store.get('videoFileType')], `${cachePath}/temp/${allowedVideos[i]}.mov`, () => {
                 fs.copyFileSync(`${cachePath}/temp/${allowedVideos[i]}.mov`, `${cachePath}/${allowedVideos[i]}.mov`);
                 fs.unlink(`${cachePath}/temp/${allowedVideos[i]}.mov`, (err) => {
                 });

--- a/app.js
+++ b/app.js
@@ -954,6 +954,9 @@ function clearCacheTemp() {
     if (!fs.existsSync(`${app.getPath('userData')}/videos/temp`)) {
         fs.mkdirSync(`${app.getPath('userData')}/videos/temp`);
     }
+    if(!fs.existsSync(cachePath + "\\temp")){
+        fs.mkdirSync(cachePath + "\\temp");
+    }
     let dir = fs.readdirSync(cachePath + "\\temp").forEach(file => {
         if (fs.existsSync(`${cachePath}/temp/${file}`)) {
             fs.unlink(`${cachePath}/temp/${file}`, (err) => {

--- a/json-editor/index.js
+++ b/json-editor/index.js
@@ -22,7 +22,9 @@ function createJSON() {
             'id' : newData[i].id,
             'accessibilityLabel' : newData[i].accessibilityLabel,
             'src' : {
-                'H2641080p' : newData[i]["url-1080-H264"]
+                'H2641080p' : newData[i]["url-1080-H264"],
+                'H2651080p' : newData[i]["url-1080-SDR"],
+                'H2654k' : newData[i]["url-4K-SDR"]
             }
             }
         )
@@ -53,6 +55,31 @@ function updateJSON() {
         }
     }
     document.getElementById('output').value = beautify(videos.sort(sortVideos),null,2,128);
+}
+
+function updateSource(){
+    let newData = JSON.parse(document.getElementById('input').value);
+    let newVideos = [];
+    for (const vid in newData) {
+        let index = videos.findIndex((e) => {
+            if(newData[vid].id === e.id){
+                return true;
+            }
+        });
+        if(index > -1) {
+            newVideos.push({
+                'id' : videos[index].id,
+                "accessibilityLabel": videos[index].accessibilityLabel,
+                "name": videos[index].name,
+                "pointsOfInterest": videos[index].pointsOfInterest,
+                "type": videos[index].type,
+                "timeOfDay": videos[index].timeOfDay,
+                'src': newData[vid].src
+            });
+        }
+    }
+    console.log(newVideos.length,videos.length);
+    document.getElementById('output').value = beautify(newVideos,null,2,128);
 }
 
 function addToJSON() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aerial",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "videoJSONVersion": "1.15.0",
   "description": "Apple TV screen saver for Windows",
   "main": "app.js",

--- a/videos.json
+++ b/videos.json
@@ -2,9 +2,6 @@
   {
     "id": "2F72BC1E-3D76-456C-81EB-842EBA488C27",
     "accessibilityLabel": "Africa and the Middle East",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A103_C002_0205DG_v12_SDR_FINAL_20180706_SDR_2K_AVC.mov"
-    },
     "name": "Africa and the Middle East",
     "pointsOfInterest": {
       "0": "Over the Horn of Africa traveling toward the Gulf of Adeno",
@@ -18,14 +15,16 @@
       "315": "The Tian Shan mountains in Central Asia"
     },
     "type": "space",
-    "timeOfDay": "day"
+    "timeOfDay": "day",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A103_C002_0205DG_v12_SDR_FINAL_20180706_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A103_C002_0205DG_v12_SDR_FINAL_20180706_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A103_C002_0205DG_v12_SDR_FINAL_20180706_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "A837FA8C-C643-4705-AE92-074EFDD067F7",
     "accessibilityLabel": "Africa Night",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT312_162NC_139M_1041_AFRICA_NIGHT_v14_SDR_FINAL_20180706_SDR_2K_AVC.mov"
-    },
     "name": "Africa Night",
     "pointsOfInterest": {
       "0": "Traveling northeast over the Sahara at night",
@@ -39,51 +38,53 @@
       "230": "Traveling over Ukraine toward Russia"
     },
     "type": "space",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT312_162NC_139M_1041_AFRICA_NIGHT_v14_SDR_FINAL_20180706_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT312_162NC_139M_1041_AFRICA_NIGHT_v14_SDR_FINAL_20180706_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT312_162NC_139M_1041_AFRICA_NIGHT_v14_SDR_FINAL_20180706_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "C7AD3D0A-7EDF-412C-A237-B3C9D27381A1",
     "accessibilityLabel": "Alaskan Jellies",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/g201_AK_A003_C014_SDR_20191113_SDR_2K_AVC.mov"
-    },
     "name": "Alaskan Jellies 1",
-    "pointsOfInterest": {
-      "0": "Drifting over Moon Jellyfish near the coast of Alaska United States"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Drifting over Moon Jellyfish near the coast of Alaska United States" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/g201_AK_A003_C014_SDR_20191113_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/g201_AK_A003_C014_SDR_20191113_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/g201_AK_A003_C014_SDR_20191113_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "C6DC4E54-1130-44F8-AF6F-A551D8E8A181",
     "accessibilityLabel": "Alaskan Jellies",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/AK_A004_C012_SDR_20191217_SDR_2K_AVC.mov"
-    },
     "name": "Alaskan Jellies 2",
-    "pointsOfInterest": {
-      "0": "Drifting under Moon Jellyfish near the coast of Alaska United States"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Drifting under Moon Jellyfish near the coast of Alaska United States" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/AK_A004_C012_SDR_20191217_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/AK_A004_C012_SDR_20191217_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/AK_A004_C012_SDR_20191217_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "03EC0F5E-CCA8-4E0A-9FEC-5BD1CE151182",
     "accessibilityLabel": "Antarctica",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT110_112NC_364D_1054_AURORA_ANTARTICA__COMP_FINAL_v34_PS_SDR_20181107_SDR_2K_AVC.mov"
-    },
     "name": "Antartica",
-    "pointsOfInterest": {
-      "0": "Aurora Australis over Antarctica"
-    },
+    "pointsOfInterest": { "0": "Aurora Australis over Antarctica" },
     "type": "space",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT110_112NC_364D_1054_AURORA_ANTARTICA__COMP_FINAL_v34_PS_SDR_20181107_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT110_112NC_364D_1054_AURORA_ANTARTICA__COMP_FINAL_v34_PS_SDR_20181107_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT110_112NC_364D_1054_AURORA_ANTARTICA__COMP_FINAL_v34_PS_SDR_20181107_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "64D11DAB-3B57-4F14-AD2F-E59A9282FA44",
     "accessibilityLabel": "Atlantic Ocean to Spain and France",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A001_C001_120530_v04_SDR_FINAL_20180706_SDR_2K_AVC.mov"
-    },
     "name": "Atlantic Ocean to Spain and France",
     "pointsOfInterest": {
       "0": "Over the North Atlantic Ocean heading toward Portugal",
@@ -91,14 +92,16 @@
       "150": "Moving away from the Iberian Peninsula and passing over the Bay of Biscay and France",
       "180": "Over Western Europe with the North Atlantic Ocean in the distance"
     },
-    "type": "space"
+    "type": "space",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A001_C001_120530_v04_SDR_FINAL_20180706_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A001_C001_120530_v04_SDR_FINAL_20180706_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A001_C001_120530_v04_SDR_FINAL_20180706_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "81337355-E156-4242-AAF4-711768D30A54",
     "accessibilityLabel": "Australia",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT060_117NC_363D_1034_AUSTRALIA_v35_SDR_PS_FINAL_20180731_SDR_2K_AVC.mov"
-    },
     "name": "Australia",
     "pointsOfInterest": {
       "0": "Over the Indian Ocean heading toward Perth Australia",
@@ -107,62 +110,64 @@
       "220": "Over Northern Territory Australia moving toward New Guinea",
       "335": "Over the Arafura Sea traveling toward New Guineao"
     },
-    "type": "space"
+    "type": "space",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT060_117NC_363D_1034_AUSTRALIA_v35_SDR_PS_FINAL_20180731_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT060_117NC_363D_1034_AUSTRALIA_v35_SDR_PS_FINAL_20180731_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT060_117NC_363D_1034_AUSTRALIA_v35_SDR_PS_FINAL_20180731_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "2B30E324-E4FF-4CC1-BA45-A958C2D2B2EC",
     "accessibilityLabel": "Barracuda",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/BO_A018_C029_SDR_20190812_SDR_2K_AVC.mov"
-    },
     "name": "Barracuda",
-    "pointsOfInterest": {
-      "0": "A school of Chevron Barracuda in the waters near Borne"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "A school of Chevron Barracuda in the waters near Borne" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/BO_A018_C029_SDR_20190812_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/BO_A018_C029_SDR_20190812_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/BO_A018_C029_SDR_20190812_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "687D03A2-18A5-4181-8E85-38F3A13409B9",
     "accessibilityLabel": "Bumpheads",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/BO_A014_C008_SDR_20190719_SDR_2K_AVC.mov"
-    },
     "name": "Bumpheads",
-    "pointsOfInterest": {
-      "0": "Bumphead Parrotfish over the coral reefs off Borneoo"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Bumphead Parrotfish over the coral reefs off Borneoo" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/BO_A014_C008_SDR_20190719_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/BO_A014_C008_SDR_20190719_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/BO_A014_C008_SDR_20190719_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "27A37B0F-738D-4644-A7A4-E33E7A6C1175",
     "accessibilityLabel": "California Dolphins",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/DL_B002_C011_SDR_20191122_SDR_2K_AVC.mov"
-    },
     "name": "California Dolphins",
-    "pointsOfInterest": {
-      "0": "Short-beaked Common Dolphins off the California coast, United States"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Short-beaked Common Dolphins off the California coast, United States" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/DL_B002_C011_SDR_20191122_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/DL_B002_C011_SDR_20191122_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/DL_B002_C011_SDR_20191122_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "EB3F48E7-D30F-4079-858F-1A61331D5026",
     "accessibilityLabel": "California Kelp Forest",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/g201_CA_A016_C002_SDR_20191114_SDR_2K_AVC.mov"
-    },
     "name": "California Kelp Forest",
-    "pointsOfInterest": {
-      "0": "Moving through a kelp forest off of the California coast, United States"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Moving through a kelp forest off of the California coast, United States" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/g201_CA_A016_C002_SDR_20191114_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/g201_CA_A016_C002_SDR_20191114_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/g201_CA_A016_C002_SDR_20191114_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "12318CCB-3F78-43B7-A854-EFDCCE5312CD",
     "accessibilityLabel": "California to Vegas",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT306_139NC_139J_3066_CALI_TO_VEGAS_v08_SDR_PS_20180824_SDR_2K_AVC.mov"
-    },
     "name": "California to Vegas",
     "pointsOfInterest": {
       "0": "Over the Pacific Ocean moving toward the California coast",
@@ -175,14 +180,16 @@
       "170": "Over the Rocky Mountains in the United States"
     },
     "type": "space",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT306_139NC_139J_3066_CALI_TO_VEGAS_v08_SDR_PS_20180824_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT306_139NC_139J_3066_CALI_TO_VEGAS_v08_SDR_PS_20180824_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT306_139NC_139J_3066_CALI_TO_VEGAS_v08_SDR_PS_20180824_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "1088217C-1410-4CF7-BDE9-8F573A4DBCD9",
     "accessibilityLabel": "Caribbean",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A105_C002_v06_SDR_FINAL_25062018_SDR_2K_AVC.mov"
-    },
     "name": "Caribbean to Central America",
     "pointsOfInterest": {
       "0": "Over the Pacific Ocean moving toward Central America",
@@ -193,14 +200,16 @@
       "300": "Over Florida and the Bahamas traveling toward the Sargasso Seao",
       "350": "Over the Sargasso Sea heading out into the Atlantic Ocean"
     },
-    "type": "space"
+    "type": "space",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A105_C002_v06_SDR_FINAL_25062018_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A105_C002_v06_SDR_FINAL_25062018_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A105_C002_v06_SDR_FINAL_25062018_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "D5CFB2FF-5F8C-4637-816B-3E42FC1229B8",
     "accessibilityLabel": "Caribbean",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A108_C001_v09_SDR_FINAL_22062018_SDR_2K_AVC.mov"
-    },
     "name": "Caribbean",
     "pointsOfInterest": {
       "0": "Traveling over the Pacific Ocean toward Central America",
@@ -213,14 +222,16 @@
       "170": "Traveling over the Bahamas looking toward Haiti and the Dominican Republic"
     },
     "type": "space",
-    "timeOfDay": "day"
+    "timeOfDay": "day",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A108_C001_v09_SDR_FINAL_22062018_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A108_C001_v09_SDR_FINAL_22062018_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A108_C001_v09_SDR_FINAL_22062018_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "4F881F8B-A7D9-4FDB-A917-17BF6AC5A589",
     "accessibilityLabel": "Caribbean Day",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT308_139K_142NC_CARIBBEAN_DAY_v09_SDR_FINAL_22062018_SDR_2K_AVC.mov"
-    },
     "name": "Caribbean Day",
     "pointsOfInterest": {
       "0": "Heading southeast over the Great Plains of the United States",
@@ -233,26 +244,52 @@
       "315": "Over the Caribbean Sea heading south toward Venezuela"
     },
     "type": "space",
-    "timeOfDay": "day"
+    "timeOfDay": "day",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT308_139K_142NC_CARIBBEAN_DAY_v09_SDR_FINAL_22062018_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT308_139K_142NC_CARIBBEAN_DAY_v09_SDR_FINAL_22062018_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT308_139K_142NC_CARIBBEAN_DAY_v09_SDR_FINAL_22062018_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "9CCB8297-E9F5-4699-AE1F-890CFBD5E29C",
     "accessibilityLabel": "China",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_CH_C002_C005_PSNK_v05_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov"
-    },
     "name": "Longji Rice Terraces",
-    "pointsOfInterest": {
-      "0": "Passing over the Longji rice terraces in Guangxi Province China"
-    },
-    "type": "cityscape"
+    "pointsOfInterest": { "0": "Passing over the Longji rice terraces in Guangxi Province China" },
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_CH_C002_C005_PSNK_v05_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_CH_C002_C005_PSNK_v05_SDR_PS_FINAL_20180709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_CH_C002_C005_PSNK_v05_SDR_PS_FINAL_20180709_SDR_4K_HEVC.mov"
+    }
+  },
+  {
+    "id": "D5E76230-81A3-4F65-A1BA-51B8CADED625",
+    "accessibilityLabel": "China",
+    "name": "Wulingyuan National Park 2",
+    "pointsOfInterest": { "0": "Exploring Wulingyuan National Park in China" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_CH_C007_C004_PSNK_v02_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_CH_C007_C004_PSNK_v02_SDR_PS_FINAL_20180709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_CH_C007_C004_PSNK_v02_SDR_PS_FINAL_20180709_SDR_4K_HEVC.mov"
+    }
+  },
+  {
+    "id": "044AD56C-A107-41B2-90CC-E60CCACFBCF5",
+    "accessibilityLabel": "China",
+    "name": "Great Wall 3",
+    "pointsOfInterest": { "0": "The Mutianyu section of the Great Wall in Huairou District China" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_C003_C003_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_C003_C003_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_C003_C003_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "6324F6EB-E0F1-468F-AC2E-A983EBDDD53B",
     "accessibilityLabel": "China",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT329_113NC_396B_1105_CHINA_v04_SDR_FINAL_20180706_F900F2700_SDR_2K_AVC.mov"
-    },
     "name": "China",
     "pointsOfInterest": {
       "0": "Over central Asia traveling toward coastal China",
@@ -261,98 +298,76 @@
       "45": "Approaching Shanghai heading toward the East China Sea",
       "50": "Over Shanghai moving toward the East China Sea"
     },
-    "type": "space"
+    "type": "space",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT329_113NC_396B_1105_CHINA_v04_SDR_FINAL_20180706_F900F2700_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT329_113NC_396B_1105_CHINA_v04_SDR_FINAL_20180706_F900F2700_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT329_113NC_396B_1105_CHINA_v04_SDR_FINAL_20180706_F900F2700_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "B876B645-3955-420E-99DF-60139E451CF3",
     "accessibilityLabel": "China",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_CH_C007_C011_PSNK_v02_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov"
-    },
     "name": "Wulingyuan National Park 1",
-    "pointsOfInterest": {
-      "0": "Traveling through Wulingyuan National Park in China"
-    },
-    "type": "landscape"
-  },
-  {
-    "id": "D5E76230-81A3-4F65-A1BA-51B8CADED625",
-    "accessibilityLabel": "China",
+    "pointsOfInterest": { "0": "Traveling through Wulingyuan National Park in China" },
+    "type": "landscape",
     "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_CH_C007_C004_PSNK_v02_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov"
-    },
-    "name": "Wulingyuan National Park 2",
-    "pointsOfInterest": {
-      "0": "Exploring Wulingyuan National Park in China"
-    },
-    "type": "landscape"
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_CH_C007_C011_PSNK_v02_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_CH_C007_C011_PSNK_v02_SDR_PS_FINAL_20180709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_CH_C007_C011_PSNK_v02_SDR_PS_FINAL_20180709_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "F0236EC5-EE72-4058-A6CE-1F7D2E8253BF",
     "accessibilityLabel": "China",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_C001_C005_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Great Wall 1",
-    "pointsOfInterest": {
-      "0": "The Mutianyu section of the Great Wall in Huairou District, China"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "The Mutianyu section of the Great Wall in Huairou District, China" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_C001_C005_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_C001_C005_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_C001_C005_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "22162A9B-DB90-4517-867C-C676BC3E8E95",
     "accessibilityLabel": "China",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_C004_C003_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Great Wall 2",
-    "pointsOfInterest": {
-      "0": "The Mutianyu section of the Great Wall in Huairou District, China"
-    },
-    "type": "landscape"
-  },
-  {
-    "id": "044AD56C-A107-41B2-90CC-E60CCACFBCF5",
-    "accessibilityLabel": "China",
+    "pointsOfInterest": { "0": "The Mutianyu section of the Great Wall in Huairou District, China" },
+    "type": "landscape",
     "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_C003_C003_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
-    "name": "Great Wall 3",
-    "pointsOfInterest": {
-      "0": "The Mutianyu section of the Great Wall in Huairou District China"
-    },
-    "type": "landscape"
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_C004_C003_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_C004_C003_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_C004_C003_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "CE9B5D5B-B6E7-47C5-8C04-59BF182E98FB",
     "accessibilityLabel": "Costa Rica Dolphins",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/CR_A009_C007_SDR_20191113_SDR_2K_AVC.mov"
-    },
     "name": "Costa Rica Dolphins",
-    "pointsOfInterest": {
-      "0": "Sea Spinner Dolphins in the waters off of Costa Rica"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Sea Spinner Dolphins in the waters off of Costa Rica" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/CR_A009_C007_SDR_20191113_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/CR_A009_C007_SDR_20191113_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/CR_A009_C007_SDR_20191113_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "58C75C62-3290-47B8-849C-56A583173570",
     "accessibilityLabel": "Cownose Rays",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/MEX_A006_C008_SDR_20190923_SDR_2K_AVC.mov"
-    },
     "name": "Cownose Rays",
-    "pointsOfInterest": {
-      "0": "Golden Cownose Rays off the coast of Mexico"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Golden Cownose Rays off the coast of Mexico" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/MEX_A006_C008_SDR_20190923_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/MEX_A006_C008_SDR_20190923_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/MEX_A006_C008_SDR_20190923_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "9680B8EB-CE2A-4395-AF41-402801F4D6A6",
     "accessibilityLabel": "Dubai",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_DB_D011_C010_PSNK_DENOISE_v19_SDR_PS_20180914_SDR_2K_AVC.mov"
-    },
     "name": "Approaching Burj Khalifa",
     "pointsOfInterest": {
       "0": "Approaching Burj Khalifa in Downtown Dubai United Arab Emirates",
@@ -360,360 +375,363 @@
       "330": "Over Downtown Dubai approaching the coast"
     },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_DB_D011_C010_PSNK_DENOISE_v19_SDR_PS_20180914_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_DB_D011_C010_PSNK_DENOISE_v19_SDR_PS_20180914_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_DB_D011_C010_PSNK_DENOISE_v19_SDR_PS_20180914_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "876D51F4-3D78-4221-8AD2-F9E78C0FD9B9",
     "accessibilityLabel": "Dubai",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_DB_D008_C010_PSNK_v21_SDR_PS_20180914_F0F16157_SDR_2K_AVC.mov"
-    },
     "name": "Sheikh Zayed Road",
-    "pointsOfInterest": {
-      "0": "Traveling along Sheikh Zayed Road in Dubai United Arab Emirates"
-    },
-    "type": "cityscape"
+    "pointsOfInterest": { "0": "Traveling along Sheikh Zayed Road in Dubai United Arab Emirates" },
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_DB_D008_C010_PSNK_v21_SDR_PS_20180914_F0F16157_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_DB_D008_C010_PSNK_v21_SDR_PS_20180914_F0F16157_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_DB_D008_C010_PSNK_v21_SDR_PS_20180914_F0F16157_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "00BA71CD-2C54-415A-A68A-8358E677D750",
     "accessibilityLabel": "Dubai",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_DB_D002_C003_PSNK_v04_SDR_PS_20180914_SDR_2K_AVC.mov"
-    },
     "name": "Downtown",
     "pointsOfInterest": {
       "0": "Approaching Downtown Dubai in the United Arab Emirates",
       "210": "Heading over Downtown Dubai in the United Arab Emirates"
     },
-    "type": "cityscape"
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_DB_D002_C003_PSNK_v04_SDR_PS_20180914_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_DB_D002_C003_PSNK_v04_SDR_PS_20180914_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_DB_D002_C003_PSNK_v04_SDR_PS_20180914_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E991AC0C-F272-44D8-88F3-05F44EDFE3AE",
     "accessibilityLabel": "Dubai",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_DB_D001_C001_PSNK_v06_SDR_PS_20180824_SDR_2K_AVC.mov"
-    },
     "name": "Marina 1",
-    "pointsOfInterest": {
-      "0": "Flying over Dubai Marina in the United Arab Emirates"
-    },
-    "type": "cityscape"
+    "pointsOfInterest": { "0": "Flying over Dubai Marina in the United Arab Emirates" },
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_DB_D001_C001_PSNK_v06_SDR_PS_20180824_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_DB_D001_C001_PSNK_v06_SDR_PS_20180824_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_DB_D001_C001_PSNK_v06_SDR_PS_20180824_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "3FFA2A97-7D28-49EA-AA39-5BC9051B2745",
     "accessibilityLabel": "Dubai",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_DB_D001_C005_COMP_PSNK_v12_SDR_PS_20180912_SDR_2K_AVC.mov"
-    },
     "name": "Marina 2",
-    "pointsOfInterest": {
-      "0": "Flying along Dubai Marina in the United Arab Emirates"
-    },
-    "type": "cityscape"
+    "pointsOfInterest": { "0": "Flying along Dubai Marina in the United Arab Emirates" },
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_DB_D001_C005_COMP_PSNK_v12_SDR_PS_20180912_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_DB_D001_C005_COMP_PSNK_v12_SDR_PS_20180912_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_DB_D001_C005_COMP_PSNK_v12_SDR_PS_20180912_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E334A6D2-7145-47C8-9B00-C20DED08B2D5",
     "accessibilityLabel": "Grand Canyon",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/G007_C004_UHD_SDR_2K_AVC.mov"
-    },
     "name": "Grand Canyon 1",
-    "pointsOfInterest": {
-      "0": "Following the Colorado River through the Grand Canyon in the United States"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Following the Colorado River through the Grand Canyon in the United States" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/G007_C004_UHD_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/G007_C004_UHD_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/G007_C004_UHD_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "DD266E1F-5DF2-4CDB-A2EB-26CE35664657",
     "accessibilityLabel": "Grand Canyon",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/G008_C015_UHD_SDR_2K_AVC.mov"
-    },
     "name": "Grand Canyon 2",
-    "pointsOfInterest": {
-      "0": "Flying over the Burnt Canyon area of the Grand Canyon, United States"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Flying over the Burnt Canyon area of the Grand Canyon, United States" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/G008_C015_UHD_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/G008_C015_UHD_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/G008_C015_UHD_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "F9F918CD-E15F-4F01-A326-84A44650C5C9",
     "accessibilityLabel": "Grand Canyon",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/G009_C003_UHD_SDR_2K_AVC.mov"
-    },
     "name": "Grand Canyon 3",
-    "pointsOfInterest": {
-      "0": "Traveling over the Grand Canyon in the United States"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Traveling over the Grand Canyon in the United States" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/G009_C003_UHD_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/G009_C003_UHD_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/G009_C003_UHD_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "AE0115AE-C53B-4DB9-B12F-CA4B7B630CC9",
     "accessibilityLabel": "Grand Canyon",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/G009_C014_UHD_SDR_2K_AVC.mov"
-    },
     "name": "Grand Canyon 4",
-    "pointsOfInterest": {
-      "0": "Traveling through the Grand Canyon in the United States"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Traveling through the Grand Canyon in the United States" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/G009_C014_UHD_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/G009_C014_UHD_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/G009_C014_UHD_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "8002C4C8-C611-4894-A068-3D3A3C03472A",
     "accessibilityLabel": "Grand Canyon",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/G010_C026_UHD_SDR_v02_2K_AVC.mov"
-    },
     "name": "Grand Canyon 5",
-    "pointsOfInterest": {
-      "0": "Traveling along the Colorado River in the Grand Canyon, United States"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Traveling along the Colorado River in the Grand Canyon, United States" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/G010_C026_UHD_SDR_v02_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/G010_C026_UHD_SDR_v02_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/G010_C026_UHD_SDR_v02_4K_HEVC.mov"
+    }
   },
   {
     "id": "3716DD4B-01C0-4F5B-8DD6-DB771EC472FB",
     "accessibilityLabel": "Gray Reef Sharks",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/FK_U009_C004_SDR_20191220_SDR_2K_AVC.mov"
-    },
     "name": "Gray Reef Sharks",
-    "pointsOfInterest": {
-      "0": "Gray Reef Sharks swimming near French Polynesia"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Gray Reef Sharks swimming near French Polynesia" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/FK_U009_C004_SDR_20191220_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/FK_U009_C004_SDR_20191220_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/FK_U009_C004_SDR_20191220_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "2F52E34C-39D4-4AB1-9025-8F7141FAA720",
     "accessibilityLabel": "Greenland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GL_G002_C002_PSNK_v03_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Ilulissat Icefjord",
-    "pointsOfInterest": {
-      "0": "The Ilulissat Icefjord off the coast of Greenland"
-    },
-    "type": "landscape"
-  },
-  {
-    "id": "EE01F02D-1413-436C-AB05-410F224A5B7B",
-    "accessibilityLabel": "Greenland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GL_G010_C006_PSNK_NOSUN_v12_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov"
-    },
-    "name": "Ilulissat Icefjord 2",
-    "pointsOfInterest": {
-      "0": "The Ilulissat Icefjord off the coast of Greenland"
-    },
+    "pointsOfInterest": { "0": "The Ilulissat Icefjord off the coast of Greenland" },
     "type": "landscape",
-    "timeOfDay": "night"
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GL_G002_C002_PSNK_v03_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GL_G002_C002_PSNK_v03_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GL_G002_C002_PSNK_v03_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "B8F204CE-6024-49AB-85F9-7CA2F6DCD226",
     "accessibilityLabel": "Greenland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GL_G004_C010_PSNK_v04_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov"
-    },
     "name": "Nuussuaq Peninsula",
-    "pointsOfInterest": {
-      "0": "Traveling along the Nuussuaq Peninsula in Greenland"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Traveling along the Nuussuaq Peninsula in Greenland" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GL_G004_C010_PSNK_v04_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GL_G004_C010_PSNK_v04_SDR_PS_FINAL_20180709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GL_G004_C010_PSNK_v04_SDR_PS_FINAL_20180709_SDR_4K_HEVC.mov"
+    }
+  },
+  {
+    "id": "EE01F02D-1413-436C-AB05-410F224A5B7B",
+    "accessibilityLabel": "Greenland",
+    "name": "Ilulissat Icefjord 2",
+    "pointsOfInterest": { "0": "The Ilulissat Icefjord off the coast of Greenland" },
+    "type": "landscape",
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GL_G010_C006_PSNK_NOSUN_v12_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GL_G010_C006_PSNK_NOSUN_v12_SDR_PS_FINAL_20180709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GL_G010_C006_PSNK_NOSUN_v12_SDR_PS_FINAL_20180709_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "3D729CFC-9000-48D3-A052-C5BD5B7A6842",
     "accessibilityLabel": "Hawaii",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_H012_C009_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Kohala Coastline",
-    "pointsOfInterest": {
-      "0": "Following the Kohala coastline on the island of Hawaii"
-    },
+    "pointsOfInterest": { "0": "Following the Kohala coastline on the island of Hawaii" },
     "type": "landscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_H012_C009_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_H012_C009_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_H012_C009_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "258A6797-CC13-4C3A-AB35-4F25CA3BF474",
     "accessibilityLabel": "Hawaii",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_H004_C009_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Pu‘u O ‘Umi",
-    "pointsOfInterest": {
-      "0": "Above the Pu‘u O ‘Umi Natural Area Reserve on the island of Hawaii"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Above the Pu‘u O ‘Umi Natural Area Reserve on the island of Hawaii" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_H004_C009_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_H004_C009_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_H004_C009_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "499995FA-E51A-4ACE-8DFD-BDF8AFF6C943",
     "accessibilityLabel": "Hawaii",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_H005_C012_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Waimanu Valley",
-    "pointsOfInterest": {
-      "0": "The Waimanu Valley in the Kohala Forest Reserve on the island of Hawaii"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "The Waimanu Valley in the Kohala Forest Reserve on the island of Hawaii" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_H005_C012_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_H005_C012_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_H005_C012_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "82BD33C9-B6D2-47E7-9C42-AA3B7758921A",
     "accessibilityLabel": "Hawaii",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_H004_C007_PS_v02_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Pu‘u O ‘Umi",
-    "pointsOfInterest": {
-      "0": "Above the Pu‘u O ‘Umi Natural Area Reserve on the island of Hawaii"
-    },
+    "pointsOfInterest": { "0": "Above the Pu‘u O ‘Umi Natural Area Reserve on the island of Hawaii" },
     "type": "landscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_H004_C007_PS_v02_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_H004_C007_PS_v02_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_H004_C007_PS_v02_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "12E0343D-2CD9-48EA-AB57-4D680FB6D0C7",
     "accessibilityLabel": "Hawaii",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_H007_C003_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Laupāhoehoe Nui",
-    "pointsOfInterest": {
-      "0": "Flying over Laupāhoehoe Nui in the Kohala Forest Reserve on the island of Hawaii"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Flying over Laupāhoehoe Nui in the Kohala Forest Reserve on the island of Hawaii" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_H007_C003_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_H007_C003_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_H007_C003_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E99FA658-A59A-4A2D-9F3B-58E7BDC71A9A",
     "accessibilityLabel": "Hong Kong",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_HK_B005_C011_PSNK_v16_SDR_PS_20180914_SDR_2K_AVC.mov"
-    },
     "name": "Victoria Harbour",
-    "pointsOfInterest": {
-      "0": "Over Victoria Harbour heading toward Central Hong Kong"
-    },
+    "pointsOfInterest": { "0": "Over Victoria Harbour heading toward Central Hong Kong" },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_HK_B005_C011_PSNK_v16_SDR_PS_20180914_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_HK_B005_C011_PSNK_v16_SDR_PS_20180914_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_HK_B005_C011_PSNK_v16_SDR_PS_20180914_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "C8559883-6F3E-4AF2-8960-903710CD47B7",
     "accessibilityLabel": "Hong Kong",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_HK_H004_C010_PSNK_v08_SDR_PS_20181009_SDR_2K_AVC.mov"
-    },
     "name": "Victoria Peak",
     "pointsOfInterest": {
       "0": "Flying over Victoria Peak in Hong Kong",
       "150": "Flying over Hong Kong toward Victoria Harbour",
       "330": "Over Victoria Harbour approaching the Kowloon Peninsulao"
     },
-    "type": "cityscape"
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_HK_H004_C010_PSNK_v08_SDR_PS_20181009_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_HK_H004_C010_PSNK_v08_SDR_PS_20181009_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_HK_H004_C010_PSNK_v08_SDR_PS_20181009_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "024891DE-B7F6-4187-BFE0-E6D237702EF0",
     "accessibilityLabel": "Hong Kong",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_HK_H004_C013_t9_6M_HB_tag0.mov"
-    },
     "name": "Wan Chai",
-    "pointsOfInterest": {
-      "0": "Over Wan Chai approaching Central Hong Kong",
-      "150": "Over Central Hong Kongo",
-      "270": "Over Hong Kong Island"
-    },
-    "type": "cityscape"
+    "pointsOfInterest": { "0": "Over Wan Chai approaching Central Hong Kong", "150": "Over Central Hong Kongo", "270": "Over Hong Kong Island" },
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_HK_H004_C013_t9_6M_HB_tag0.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/HK_H004_C013_2K_SDR_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/HK_H004_C013_4K_SDR_HEVC.mov"
+    }
   },
   {
     "id": "FE8E1F9D-59BA-4207-B626-28E34D810D0A",
     "accessibilityLabel": "Hong Kong",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_HK_H004_C008_PSNK_v19_SDR_PS_20180914_SDR_2K_AVC.mov"
-    },
     "name": "Victoria Harbour 1",
-    "pointsOfInterest": {
-      "0": "Over Victoria Harbour facing Hong Kong Island"
-    },
-    "type": "cityscape"
+    "pointsOfInterest": { "0": "Over Victoria Harbour facing Hong Kong Island" },
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_HK_H004_C008_PSNK_v19_SDR_PS_20180914_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_HK_H004_C008_PSNK_v19_SDR_PS_20180914_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_HK_H004_C008_PSNK_v19_SDR_PS_20180914_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "DD47D8E1-CB66-4C12-BFEA-2ADB0D8D1E2E",
     "accessibilityLabel": "Humpback Whale",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/g201_WH_D004_L014_SDR_20191031_SDR_2K_AVC.mov"
-    },
     "name": "Humpback Whale",
-    "pointsOfInterest": {
-      "0": "A Humpback Whale off of French Polynesia"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "A Humpback Whale off of French Polynesia" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/g201_WH_D004_L014_SDR_20191031_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/g201_WH_D004_L014_SDR_20191031_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/g201_WH_D004_L014_SDR_20191031_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "DDE50C77-B7CB-4488-9EB1-D1B13BF21FFE",
     "accessibilityLabel": "Iceland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/I003_C008_SDR_2K_AVC.mov"
-    },
     "name": "Tungnaá",
-    "pointsOfInterest": {
-      "0": "Traveling over Tungnaá in the Icelandic highlands"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Traveling over Tungnaá in the Icelandic highlands" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/I003_C008_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/I003_C008_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/I003_C008_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E54D5AFE-F362-4D48-A20D-F2C21D2B5330",
     "accessibilityLabel": "Iceland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/I003_C011_SDR_2K_AVC.mov"
-    },
     "name": "Jökulgilskvísl River",
-    "pointsOfInterest": {
-      "0": "Following the Jökulgilskvísl river in Landmannalaugar, Iceland",
-      "308": "Traveling over the Icelandic highlands"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Following the Jökulgilskvísl river in Landmannalaugar, Iceland", "308": "Traveling over the Icelandic highlands" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/I003_C011_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/I003_C011_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/I003_C011_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "8ACF5D77-B22C-416F-B12A-72FB35E2834F",
     "accessibilityLabel": "Iceland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/I004_C014_SDR_2K_AVC.mov"
-    },
     "name": "Landmannalaugar",
-    "pointsOfInterest": {
-      "0": "Traveling over Landmannalaugar in Iceland"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Traveling over Landmannalaugar in Iceland" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/I004_C014_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/I004_C014_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/I004_C014_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "F9518D54-04A7-4793-8666-CFC114D73CE5",
     "accessibilityLabel": "Iceland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/I003_C015_SDR_2K_AVC.mov"
-    },
     "name": "Jökulgil",
-    "pointsOfInterest": {
-      "0": "Traveling through Jökulgil in Landmannalaugar, Iceland"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Traveling through Jökulgil in Landmannalaugar, Iceland" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/I003_C015_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/I003_C015_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/I003_C015_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "8590D0C5-E344-4FAC-A39A-FD7BC652AEDA",
     "accessibilityLabel": "Iceland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/I003_C004_SDR_2K_AVC.mov"
-    },
     "name": "Langisjór",
-    "pointsOfInterest": {
-      "0": "Flying over Langisjór in Iceland"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Flying over Langisjór in Iceland" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/I003_C004_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/I003_C004_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/I003_C004_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "2F17FCCE-6CCA-4AFA-A08A-C50BF9812DA5",
     "accessibilityLabel": "Iceland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/I005_C008_CROP_SDR_2K_AVC.mov"
-    },
     "name": "Mýrdalsjökull Glacier",
     "pointsOfInterest": {
       "0": "Moving toward Mýrdalsjökull glacier in Iceland",
@@ -721,14 +739,16 @@
       "225": "Mýrdalsjökull glacier in Iceland",
       "324": "Traveling over Mýrdalsjökull glacier in Iceland"
     },
-    "type": "landscape"
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/I005_C008_CROP_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/I005_C008_CROP_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/I005_C008_CROP_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "F439B0A7-D18C-4B14-9681-6520E6A74FE9",
     "accessibilityLabel": "Iran and Afghanistan",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A083_C002_1130KZ_v04_SDR_PS_FINAL_20180725_SDR_2K_AVC.mov"
-    },
     "name": "Iran and Afghanistan",
     "pointsOfInterest": {
       "0": "The reflection of the sun along the coast of Iran",
@@ -736,14 +756,16 @@
       "60": "Moving from day to night over central Asia"
     },
     "type": "space",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A083_C002_1130KZ_v04_SDR_PS_FINAL_20180725_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A083_C002_1130KZ_v04_SDR_PS_FINAL_20180725_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A083_C002_1130KZ_v04_SDR_PS_FINAL_20180725_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "7C643A39-C0B2-4BA0-8BC2-2EAA47CC580E",
     "accessibilityLabel": "Ireland to Asia",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT329_117NC_401C_1037_IRELAND_TO_ASIA_v48_SDR_PS_FINAL_20180725_F0F6300_SDR_2K_AVC.mov"
-    },
     "name": "Ireland to Asia",
     "pointsOfInterest": {
       "0": "Over the North Atlantic approaching the British Isles",
@@ -757,14 +779,16 @@
       "195": "Over Russia traveling toward central Asia"
     },
     "type": "space",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT329_117NC_401C_1037_IRELAND_TO_ASIA_v48_SDR_PS_FINAL_20180725_F0F6300_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT329_117NC_401C_1037_IRELAND_TO_ASIA_v48_SDR_PS_FINAL_20180725_F0F6300_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT329_117NC_401C_1037_IRELAND_TO_ASIA_v48_SDR_PS_FINAL_20180725_F0F6300_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E5DB138A-F04E-4619-B896-DE5CB538C534",
     "accessibilityLabel": "Italy to Asia",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT329_113NC_396B_1105_ITALY_v03_SDR_FINAL_20180706_SDR_2K_AVC.mov"
-    },
     "name": "Italy to Asia",
     "pointsOfInterest": {
       "0": "Over Tunisia heading toward Italy",
@@ -776,38 +800,40 @@
       "75": "Over southwest Russia passing by Kazakhstan"
     },
     "type": "space",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT329_113NC_396B_1105_ITALY_v03_SDR_FINAL_20180706_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT329_113NC_396B_1105_ITALY_v03_SDR_FINAL_20180706_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT329_113NC_396B_1105_ITALY_v03_SDR_FINAL_20180706_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "537A4DAB-83B0-4B66-BCD1-05E5DBB4A268",
     "accessibilityLabel": "Jacks",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/BO_A014_C023_SDR_20190717_F240F3709_SDR_2K_AVC.mov"
-    },
     "name": "Jacks",
-    "pointsOfInterest": {
-      "0": "A school of Bigeye Jacks off the coast of Borneo"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "A school of Bigeye Jacks off the coast of Borneo" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/BO_A014_C023_SDR_20190717_F240F3709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/BO_A014_C023_SDR_20190717_F240F3709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/BO_A014_C023_SDR_20190717_F240F3709_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "6143116D-03BB-485E-864E-A8CF58ACF6F1",
     "accessibilityLabel": "Kelp",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/KP_A010_C002_SDR_20190717_SDR_2K_AVC.mov"
-    },
     "name": "South African Kelp",
-    "pointsOfInterest": {
-      "0": "Drifting through a kelp forest near Cape Peninsula South Africa"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Drifting through a kelp forest near Cape Peninsula South Africa" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/KP_A010_C002_SDR_20190717_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/KP_A010_C002_SDR_20190717_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/KP_A010_C002_SDR_20190717_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "009BA758-7060-4479-8EE8-FB9B40C8FB97",
     "accessibilityLabel": "Korea and Japan Night",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT026_363A_103NC_E1027_KOREA_JAPAN_NIGHT_v18_SDR_PS_20180907_SDR_2K_AVC.mov"
-    },
     "name": "Korea and Japan Night",
     "pointsOfInterest": {
       "0": "Moving southeast over Siberia and Mongolia",
@@ -821,38 +847,40 @@
       "260": "Over the Pacific Ocean southeast of Japan"
     },
     "type": "space",
-    "timeOfDay": "night"
-  },
-  {
-    "id": "001C94AE-2BA4-4E77-A202-F7DE60E8B1C8",
-    "accessibilityLabel": "Liwa",
+    "timeOfDay": "night",
     "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_LW_L001_C006_PSNK_DENOISE_v02_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov"
-    },
-    "name": "Liwa Oasis 1",
-    "pointsOfInterest": {
-      "0": "Flying over Liwa Oasis in the United Arab Emirates"
-    },
-    "type": "landscape"
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT026_363A_103NC_E1027_KOREA_JAPAN_NIGHT_v18_SDR_PS_20180907_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT026_363A_103NC_E1027_KOREA_JAPAN_NIGHT_v18_SDR_PS_20180907_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT026_363A_103NC_E1027_KOREA_JAPAN_NIGHT_v18_SDR_PS_20180907_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "AFA22C08-A486-4CE8-9A13-E355B6C38559",
     "accessibilityLabel": "Liwa",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_LW_L001_C003__PSNK_DENOISE_v04_SDR_PS_FINAL_20180803_SDR_2K_AVC.mov"
-    },
     "name": "Liwa Oasis 2",
-    "pointsOfInterest": {
-      "0": "Flying over Liwa Oasis in the United Arab Emirates"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Flying over Liwa Oasis in the United Arab Emirates" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_LW_L001_C003__PSNK_DENOISE_v04_SDR_PS_FINAL_20180803_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LW_L001_C003__PSNK_DENOISE_v04_SDR_PS_FINAL_20180803_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LW_L001_C003__PSNK_DENOISE_v04_SDR_PS_FINAL_20180803_SDR_4K_HEVC.mov"
+    }
+  },
+  {
+    "id": "001C94AE-2BA4-4E77-A202-F7DE60E8B1C8",
+    "accessibilityLabel": "Liwa",
+    "name": "Liwa Oasis 1",
+    "pointsOfInterest": { "0": "Flying over Liwa Oasis in the United Arab Emirates" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_LW_L001_C006_PSNK_DENOISE_v02_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LW_L001_C006_PSNK_DENOISE_v02_SDR_PS_FINAL_20180709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LW_L001_C006_PSNK_DENOISE_v02_SDR_PS_FINAL_20180709_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "A5AAFF5D-8887-42BB-8AFD-867EF557ED85",
     "accessibilityLabel": "London",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_L007_C007_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Buckingham Palace",
     "pointsOfInterest": {
       "0": "Passing over the grounds of Buckingham Palace London",
@@ -864,14 +892,16 @@
       "299": "Crossing the River Thames in London",
       "324": "Crossing the River Thames at Tower Bridge in London"
     },
-    "type": "cityscape"
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_L007_C007_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_L007_C007_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_L007_C007_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "F604AF56-EA77-4960-AEF7-82533CC1A8B3",
     "accessibilityLabel": "London",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_L012_c002_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "River Thames near Sunset",
     "pointsOfInterest": {
       "0": "Approaching the River Thames in London",
@@ -882,14 +912,16 @@
       "270": "Over Westminster, London"
     },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_L012_c002_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_L012_c002_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_L012_c002_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "58754319-8709-4AB0-8674-B34F04E7FFE2",
     "accessibilityLabel": "London",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_L010_C006_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "River Thames",
     "pointsOfInterest": {
       "0": "Approaching Tower Bridge on the River Thames, London",
@@ -897,14 +929,16 @@
       "178": "South of the River Thames in London",
       "258": "Crossing the River Thames in London"
     },
-    "type": "cityscape"
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_L010_C006_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_L010_C006_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_L010_C006_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "7F4C26C2-67C2-4C3A-8F07-8A7BF6148C97",
     "accessibilityLabel": "London",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_L004_C011_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "River Thames at Dusk",
     "pointsOfInterest": {
       "0": "Approaching Tower Bridge on the River Thames, London",
@@ -915,92 +949,95 @@
       "325": "Passing the Houses of Parliament on the River Thames in London"
     },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_L004_C011_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_L004_C011_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_L004_C011_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "92E48DE9-13A1-4172-B560-29B4668A87EE",
     "accessibilityLabel": "Los Angeles",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A008_C004_ALTB_ED_FROM_FLAME_RETIME_v46_SDR_PS_20180917_SDR_2K_AVC.mov"
-    },
     "name": "Santa Monica Beach",
     "pointsOfInterest": {
       "0": "Over Santa Monica State Beach near Los Angeles",
       "365": "Passing over Santa Monica Pier near Los Angeles",
       "430": "Over Santa Monica State Beach near Los Angeles"
     },
-    "type": "cityscape"
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A008_C004_ALTB_ED_FROM_FLAME_RETIME_v46_SDR_PS_20180917_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A008_C004_ALTB_ED_FROM_FLAME_RETIME_v46_SDR_PS_20180917_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A008_C004_ALTB_ED_FROM_FLAME_RETIME_v46_SDR_PS_20180917_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "35693AEA-F8C4-4A80-B77D-C94B20A68956",
     "accessibilityLabel": "Los Angeles",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A005_C009_PSNK_ALT_v09_SDR_PS_201809134_SDR_2K_AVC.mov"
-    },
     "name": "Harbor Freeway",
-    "pointsOfInterest": {
-      "0": "Following Interstate 110 north through Los Angeles"
-    },
-    "type": "cityscape"
+    "pointsOfInterest": { "0": "Following Interstate 110 north through Los Angeles" },
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A005_C009_PSNK_ALT_v09_SDR_PS_201809134_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A005_C009_PSNK_ALT_v09_SDR_PS_201809134_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A005_C009_PSNK_ALT_v09_SDR_PS_201809134_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "F5804DD6-5963-40DA-9FA0-39C0C6E6DEF9",
     "accessibilityLabel": "Los Angeles",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A011_C003_DGRN_LNFIX_STAB_v57_SDR_PS_20181002_SDR_2K_AVC.mov"
-    },
     "name": "Downtown",
-    "pointsOfInterest": {
-      "0": "Downtown Los Angeles"
-    },
+    "pointsOfInterest": { "0": "Downtown Los Angeles" },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A011_C003_DGRN_LNFIX_STAB_v57_SDR_PS_20181002_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A011_C003_DGRN_LNFIX_STAB_v57_SDR_PS_20181002_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A011_C003_DGRN_LNFIX_STAB_v57_SDR_PS_20181002_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "EC67726A-8212-4C5E-83CF-8412932740D2",
     "accessibilityLabel": "Los Angeles",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A006_C004_v01_SDR_FINAL_PS_20180730_SDR_2K_AVC.mov"
-    },
     "name": "Hollywood Hills",
-    "pointsOfInterest": {
-      "0": "The Hollywood Sign in Los Angeles",
-      "250": "Over the Hollywood Hills approaching Burbank California"
-    },
+    "pointsOfInterest": { "0": "The Hollywood Sign in Los Angeles", "250": "Over the Hollywood Hills approaching Burbank California" },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A006_C004_v01_SDR_FINAL_PS_20180730_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A006_C004_v01_SDR_FINAL_PS_20180730_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A006_C004_v01_SDR_FINAL_PS_20180730_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "CE279831-1CA7-4A83-A97B-FF1E20234396",
     "accessibilityLabel": "Los Angeles",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A006_C008_PSNK_ALL_LOGOS_v10_SDR_PS_FINAL_20180801_SDR_2K_AVC.mov"
-    },
     "name": "Los Angeles Int’l Airport",
-    "pointsOfInterest": {
-      "0": "Heading west over Los Angeles International Airport"
-    },
-    "type": "cityscape"
+    "pointsOfInterest": { "0": "Heading west over Los Angeles International Airport" },
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A006_C008_PSNK_ALL_LOGOS_v10_SDR_PS_FINAL_20180801_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A006_C008_PSNK_ALL_LOGOS_v10_SDR_PS_FINAL_20180801_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A006_C008_PSNK_ALL_LOGOS_v10_SDR_PS_FINAL_20180801_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "89B1643B-06DD-4DEC-B1B0-774493B0F7B7",
     "accessibilityLabel": "Los Angeles",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A009_C009_PSNK_v02_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov"
-    },
     "name": "Griffith Observatory",
-    "pointsOfInterest": {
-      "0": "Griffith Observatory and the Hollywood Hills in Los Angeles"
-    },
+    "pointsOfInterest": { "0": "Griffith Observatory and the Hollywood Hills in Los Angeles" },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_LA_A009_C009_PSNK_v02_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A009_C009_PSNK_v02_SDR_PS_FINAL_20180709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_LA_A009_C009_PSNK_v02_SDR_PS_FINAL_20180709_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "44166C39-8566-4ECA-BD16-43159429B52F",
     "accessibilityLabel": "New York",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_N013_C004_PS_v01_SDR_PS_20180925_F1970F7193_SDR_2K_AVC.mov"
-    },
     "name": "Seventh Avenue",
     "pointsOfInterest": {
       "0": "Heading down 7th Avenue toward Times Square New York",
@@ -1008,27 +1045,28 @@
       "120": "Heading down 7th Avenue in Midtown Manhattan, New York"
     },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_N013_C004_PS_v01_SDR_PS_20180925_F1970F7193_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_N013_C004_PS_v01_SDR_PS_20180925_F1970F7193_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_N013_C004_PS_v01_SDR_PS_20180925_F1970F7193_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "3BA0CFC7-E460-4B59-A817-B97F9EBB9B89",
     "accessibilityLabel": "New York",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_N008_C009_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Central Park",
-    "pointsOfInterest": {
-      "0": "Over Central Park traveling toward Midtown Manhattan in New York",
-      "246": "Over Midtown Manhattan in New York"
-    },
-    "type": "cityscape"
+    "pointsOfInterest": { "0": "Over Central Park traveling toward Midtown Manhattan in New York", "246": "Over Midtown Manhattan in New York" },
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_N008_C009_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_N008_C009_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_N008_C009_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "640DFB00-FBB9-45DA-9444-9F663859F4BC",
     "accessibilityLabel": "New York",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_N008_C003_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Lower Manhattan",
     "pointsOfInterest": {
       "0": "Approaching Lower Manhattan from New York Harbor",
@@ -1037,14 +1075,16 @@
       "210": "Over Lower Manhattan in New York moving toward Midtown"
     },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_N008_C003_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_N008_C003_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_N008_C003_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "840FE8E4-D952-4680-B1A7-AC5BACA2C1F8",
     "accessibilityLabel": "New York",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_N003_C006_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Upper East Side",
     "pointsOfInterest": {
       "0": "Over the Upper East Side and Central Park in New York",
@@ -1052,14 +1092,16 @@
       "160": "Approaching the Empire State Building in New York",
       "205": "Passing the Empire State Building moving toward Lower Manhattan"
     },
-    "type": "cityscape"
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_N003_C006_PS_v01_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_N003_C006_PS_v01_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_N003_C006_PS_v01_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "B1B5DDC5-73C8-4920-8133-BACCE38A08DE",
     "accessibilityLabel": "New York Night",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT307_136NC_134K_8277_NY_NIGHT_01_v25_SDR_PS_20180907_SDR_2K_AVC.mov"
-    },
     "name": "Mexico City to New York",
     "pointsOfInterest": {
       "0": "Over the Pacific Ocean heading toward Mexico",
@@ -1072,14 +1114,16 @@
       "320": "Over the eastern United States approaching New York City"
     },
     "type": "space",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT307_136NC_134K_8277_NY_NIGHT_01_v25_SDR_PS_20180907_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT307_136NC_134K_8277_NY_NIGHT_01_v25_SDR_PS_20180907_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT307_136NC_134K_8277_NY_NIGHT_01_v25_SDR_PS_20180907_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "78911B7E-3C69-47AD-B635-9C2486F6301D",
     "accessibilityLabel": "New Zealand",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A105_C003_0212CT_FLARE_v10_SDR_PS_FINAL_20180711_SDR_2K_AVC.mov"
-    },
     "name": "New Zealand",
     "pointsOfInterest": {
       "0": "Crossing from night to day over the South Pacific Ocean",
@@ -1088,14 +1132,16 @@
       "170": "Leaving New Zealand heading northeast over the Pacific Ocean"
     },
     "type": "space",
-    "timeOfDay": "day"
+    "timeOfDay": "day",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A105_C003_0212CT_FLARE_v10_SDR_PS_FINAL_20180711_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A105_C003_0212CT_FLARE_v10_SDR_PS_FINAL_20180711_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A105_C003_0212CT_FLARE_v10_SDR_PS_FINAL_20180711_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "3C4678E4-4D3D-4A40-8817-77752AEA62EB",
     "accessibilityLabel": "Nile Delta",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A050_C004_1027V8_v16_SDR_FINAL_20180706_SDR_2K_AVC.mov"
-    },
     "name": "Nile Delta",
     "pointsOfInterest": {
       "0": "Traveling over Western Europe with the British Isles in the distance",
@@ -1108,14 +1154,16 @@
       "220": "The Eastern Desert flanked by the Nile River and the Gulf of Suez",
       "240": "Heading southeast over the Red Sea"
     },
-    "type": "space"
+    "type": "space",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A050_C004_1027V8_v16_SDR_FINAL_20180706_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A050_C004_1027V8_v16_SDR_FINAL_20180706_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A050_C004_1027V8_v16_SDR_FINAL_20180706_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "737E9E24-49BE-4104-9B72-F352DE1AD2BF",
     "accessibilityLabel": "North America Aurora",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT314_139M_170NC_NORTH_AMERICA_AURORA__COMP_v22_SDR_20181206_v12CC_SDR_2K_AVC.mov"
-    },
     "name": "North America Aurora",
     "pointsOfInterest": {
       "0": "Over the Pacific Ocean moving toward Baja, California",
@@ -1132,124 +1180,128 @@
       "300": "Heading toward the North Atlantic with the Aurora Borealis over Labrador, Canada"
     },
     "type": "space",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_GMT314_139M_170NC_NORTH_AMERICA_AURORA__COMP_v22_SDR_20181206_v12CC_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT314_139M_170NC_NORTH_AMERICA_AURORA__COMP_v22_SDR_20181206_v12CC_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_GMT314_139M_170NC_NORTH_AMERICA_AURORA__COMP_v22_SDR_20181206_v12CC_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "F07CC61B-30FC-4614-BDAD-3240B61F6793",
     "accessibilityLabel": "Palau Coral",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/PA_A004_C003_SDR_20190719_SDR_2K_AVC.mov"
-    },
     "name": "Palau Coral",
-    "pointsOfInterest": {
-      "0": "Coral reef near Palauo"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Coral reef near Palauo" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/PA_A004_C003_SDR_20190719_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/PA_A004_C003_SDR_20190719_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/PA_A004_C003_SDR_20190719_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "BA4ECA11-592F-4727-9221-D2A32A16EB28",
     "accessibilityLabel": "Palau Jellies",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/PA_A001_C007_SDR_20190717_SDR_2K_AVC.mov"
-    },
     "name": "Palau Jellies 1",
     "pointsOfInterest": {
       "0": "Golden Jellyfish in the waters of Palau",
       "282": "Golden Jellyfish with a Moon Jellyfish in their midst",
       "348": "Golden Jellyfish in the waters of Palau"
     },
-    "type": "underwater"
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/PA_A001_C007_SDR_20190717_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/PA_A001_C007_SDR_20190717_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/PA_A001_C007_SDR_20190717_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E580E5A5-0888-4BE8-A4CA-F74A18A643C3",
     "accessibilityLabel": "Palau Jellies",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/PA_A002_C009_SDR_20190730_ALT01_SDR_2K_AVC.mov"
-    },
     "name": "Palau Jellies 2",
-    "pointsOfInterest": {
-      "0": "Golden Jellyfish in the waters of Palau"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Golden Jellyfish in the waters of Palau" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/PA_A002_C009_SDR_20190730_ALT01_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/PA_A002_C009_SDR_20190730_ALT01_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/PA_A002_C009_SDR_20190730_ALT01_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "EC3DC957-D4C2-4732-AACE-7D0C0F390EC8",
     "accessibilityLabel": "Palau Jellies",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/PA_A010_C007_SDR_20190717_SDR_2K_AVC.mov"
-    },
     "name": "Palau Jellies 3",
-    "pointsOfInterest": {
-      "0": "Golden Jellyfish in the waters of Palauo"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Golden Jellyfish in the waters of Palauo" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/PA_A010_C007_SDR_20190717_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/PA_A010_C007_SDR_20190717_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/PA_A010_C007_SDR_20190717_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "5C987900-AD53-469C-8210-CABBCCDDFCAE",
     "accessibilityLabel": "Patagonia",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/P001_C005_UHD_SDR_2K_AVC.mov"
-    },
     "name": "Cuernos del Paine",
-    "pointsOfInterest": {
-      "0": "Moving along Cuernos del Paine in Torres del Paine National Park, Chile"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Moving along Cuernos del Paine in Torres del Paine National Park, Chile" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/P001_C005_UHD_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/P001_C005_UHD_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/P001_C005_UHD_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "B004358B-5A27-42E5-B49E-93FC100B2371",
     "accessibilityLabel": "Patagonia",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/P005_C002_UHD_SDR_2K_AVC.mov"
-    },
     "name": "Lago Nordenskjöld 1",
-    "pointsOfInterest": {
-      "0": "Traveling along Lago Nordenskjöld in Torres del Paine National Park, Chile"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Traveling along Lago Nordenskjöld in Torres del Paine National Park, Chile" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/P005_C002_UHD_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/P005_C002_UHD_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/P005_C002_UHD_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "25A6CFB2-3570-4448-B114-244A4E454B7A",
     "accessibilityLabel": "Patagonia",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/P006_C002_UHD_SDR_2K_AVC.mov"
-    },
     "name": "Lago Nordenskjöld 2",
-    "pointsOfInterest": {
-      "0": "Over Lago Nordenskjöld in Torres del Paine National Park, Chile"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Over Lago Nordenskjöld in Torres del Paine National Park, Chile" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/P006_C002_UHD_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/P006_C002_UHD_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/P006_C002_UHD_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E5D58CC2-3C52-4206-9DA2-427DC88B5896",
     "accessibilityLabel": "Patagonia",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/P007_C027_UHD_SDR_2K_AVC.mov"
-    },
     "name": "Torres del Paine National Park",
-    "pointsOfInterest": {
-      "0": "Traveling over Torres del Paine National Park in Chile"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Traveling over Torres del Paine National Park in Chile" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/P007_C027_UHD_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/P007_C027_UHD_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/P007_C027_UHD_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "82175C1F-153C-4EC8-AE37-2860EA828004",
     "accessibilityLabel": "Red Sea Coral",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/RS_A008_C010_SDR_20191218_SDR_2K_AVC.mov"
-    },
     "name": "Red Sea Coral",
-    "pointsOfInterest": {
-      "0": "Coral reef in the Red Sea near Egypt"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Coral reef in the Red Sea near Egypt" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/RS_A008_C010_SDR_20191218_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/RS_A008_C010_SDR_20191218_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/RS_A008_C010_SDR_20191218_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E556BBC5-D0A0-4DB1-AC77-BC76E4A526F4",
     "accessibilityLabel": "Sahara and Italy",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A009_C001_010181A_v09_SDR_PS_FINAL_20180725_SDR_2K_AVC.mov"
-    },
     "name": "Sahara and Italy",
     "pointsOfInterest": {
       "0": "Over western Africa moving toward the Saharao",
@@ -1264,14 +1316,16 @@
       "310": "The Carpathian Mountains and the Black Sea"
     },
     "type": "space",
-    "timeOfDay": "day"
+    "timeOfDay": "day",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A009_C001_010181A_v09_SDR_PS_FINAL_20180725_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A009_C001_010181A_v09_SDR_PS_FINAL_20180725_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A009_C001_010181A_v09_SDR_PS_FINAL_20180725_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "72B4390D-DF1D-4D51-B179-229BBAEFFF2C",
     "accessibilityLabel": "San Francisco",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A013_C012_0122D6_CC_v01_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov"
-    },
     "name": "Golden Gate from SF",
     "pointsOfInterest": {
       "0": "Approaching the Golden Gate Bridge from San Francisco",
@@ -1280,14 +1334,16 @@
       "230": "Passing by the North Tower of the Golden Gate Bridge",
       "260": "Over San Francisco Bay traveling alongside the Golden Gate Bridge"
     },
-    "type": "cityscape"
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A013_C012_0122D6_CC_v01_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A013_C012_0122D6_CC_v01_SDR_PS_FINAL_20180709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A013_C012_0122D6_CC_v01_SDR_PS_FINAL_20180709_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "3E94AE98-EAF2-4B09-96E3-452F46BC114E",
     "accessibilityLabel": "San Francisco",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A015_C018_0128ZS_v03_SDR_PS_FINAL_20180709__SDR_2K_AVC.mov"
-    },
     "name": "Bay Bridge",
     "pointsOfInterest": {
       "0": "Approaching the Bay Bridge and downtown San Francisco",
@@ -1295,28 +1351,32 @@
       "116": "Over San Francisco Bay heading toward downtown"
     },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A015_C018_0128ZS_v03_SDR_PS_FINAL_20180709__SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A015_C018_0128ZS_v03_SDR_PS_FINAL_20180709__SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A015_C018_0128ZS_v03_SDR_PS_FINAL_20180709__SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "DE851E6D-C2BE-4D9F-AB54-0F9CE994DC51",
     "accessibilityLabel": "San Francisco",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A006_C003_1219EE_CC_v01_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov"
-    },
     "name": "Bay and Golden Gate",
     "pointsOfInterest": {
       "0": "San Francisco Bay and the Golden Gate Bridge",
       "140": "Heading over the north tower of the Golden Gate Bridge toward San Francisco",
       "191": "Over San Francisco Bay"
     },
-    "type": "cityscape"
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A006_C003_1219EE_CC_v01_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A006_C003_1219EE_CC_v01_SDR_PS_FINAL_20180709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A006_C003_1219EE_CC_v01_SDR_PS_FINAL_20180709_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "4AD99907-9E76-408D-A7FC-8429FF014201",
     "accessibilityLabel": "San Francisco",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_1223LV_FLARE_v21_SDR_PS_FINAL_20180709_F0F5700_SDR_2K_AVC.mov"
-    },
     "name": "Bay and Embarcadero",
     "pointsOfInterest": {
       "0": "Over the San Francisco Bay moving toward the Embarcader",
@@ -1324,40 +1384,43 @@
       "150": "Following Market Street through downtown San Francisco",
       "360": "Following Market Street through San Francisco"
     },
-    "type": "cityscape"
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_1223LV_FLARE_v21_SDR_PS_FINAL_20180709_F0F5700_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_1223LV_FLARE_v21_SDR_PS_FINAL_20180709_F0F5700_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_1223LV_FLARE_v21_SDR_PS_FINAL_20180709_F0F5700_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "EE533FBD-90AE-419A-AD13-D7A60E2015D6",
     "accessibilityLabel": "San Francisco",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A008_C007_011550_CC_v01_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov"
-    },
     "name": "Marin Headlands in Fog",
     "pointsOfInterest": {
       "0": "Over the Marin Headlands looking toward the Golden Gate Bridge",
       "150": "Crossing the Golden Gate Bridge toward the Presidio of San Francisco"
     },
-    "type": "cityscape"
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A008_C007_011550_CC_v01_SDR_PS_FINAL_20180709_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A008_C007_011550_CC_v01_SDR_PS_FINAL_20180709_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A008_C007_011550_CC_v01_SDR_PS_FINAL_20180709_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "85CE77BF-3413-4A7B-9B0F-732E96229A73",
     "accessibilityLabel": "San Francisco",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A012_C014_1223PT_v53_SDR_PS_FINAL_20180709_F0F8700_SDR_2K_AVC.mov"
-    },
     "name": "Embarcadero, Market Street",
-    "pointsOfInterest": {
-      "0": "Over San Francisco Bay moving toward the Embarcader",
-      "208": "Following Market Street through San Francisco"
-    },
-    "type": "cityscape"
+    "pointsOfInterest": { "0": "Over San Francisco Bay moving toward the Embarcader", "208": "Following Market Street through San Francisco" },
+    "type": "cityscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A012_C014_1223PT_v53_SDR_PS_FINAL_20180709_F0F8700_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A012_C014_1223PT_v53_SDR_PS_FINAL_20180709_F0F8700_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A012_C014_1223PT_v53_SDR_PS_FINAL_20180709_F0F8700_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "29BDF297-EB43-403A-8719-A78DA11A2948",
     "accessibilityLabel": "San Francisco",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A007_C017_01156B_v02_SDR_PS_20180925_SDR_2K_AVC.mov"
-    },
     "name": "Fisherman’s Wharf",
     "pointsOfInterest": {
       "0": "Over Fisherman's Wharf heading toward downtown San Francisco",
@@ -1366,28 +1429,32 @@
       "196": "Downtown San Francisco"
     },
     "type": "cityscape",
-    "timeOfDay": "night"
+    "timeOfDay": "night",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A007_C017_01156B_v02_SDR_PS_20180925_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A007_C017_01156B_v02_SDR_PS_20180925_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A007_C017_01156B_v02_SDR_PS_20180925_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "0C747C29-4BF8-43F6-A5CC-2E012E555341",
     "accessibilityLabel": "Scotland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/S003_C020_SDR_2K_AVC.mov"
-    },
     "name": "Isle of Skye",
     "pointsOfInterest": {
       "0": "Traveling along the coast of the Isle of Skye, Scotland",
       "338": "Neist Point Lighthouse, Isle of Skye, Scotland",
       "372": "Over Victoria Harbour heading toward Central Hong Kong"
     },
-    "type": "landscape"
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/S003_C020_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/S003_C020_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/S003_C020_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E161929C-0819-4BC2-8359-550C081C7D54",
     "accessibilityLabel": "Scotland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/S006_C007_SDR_2K_AVC.mov"
-    },
     "name": "Castle Tioram",
     "pointsOfInterest": {
       "0": "Loch Moidart on the west coast of Scotland",
@@ -1395,51 +1462,52 @@
       "181": "Castle Tioramon, the west coast of Scotland",
       "214": "Traveling over the west coast of Scotland"
     },
-    "type": "landscape"
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/S006_C007_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/S006_C007_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/S006_C007_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "3954A7C4-51EC-4ABC-ABA3-6757AC91C7CF",
     "accessibilityLabel": "Scotland",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/S005_C015_SDR_2K_AVC.mov"
-    },
     "name": "Loch Moidart",
-    "pointsOfInterest": {
-      "0": "Over Loch Moidart on the west coast of Scotland",
-      "252": "Approaching the Sea of Hebrides, Scotland"
-    },
-    "type": "landscape"
+    "pointsOfInterest": { "0": "Over Loch Moidart on the west coast of Scotland", "252": "Approaching the Sea of Hebrides, Scotland" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/S005_C015_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/S005_C015_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/S005_C015_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "581A4F1A-2B6D-468C-A1BE-6F473F06D10B",
     "accessibilityLabel": "Sea Stars",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/BO_A012_C031_SDR_20190726_SDR_2K_AVC.mov"
-    },
     "name": "Sea Stars",
-    "pointsOfInterest": {
-      "0": "Horned Sea Stars on the ocean floor near Borneo"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Horned Sea Stars on the ocean floor near Borneo" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/BO_A012_C031_SDR_20190726_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/BO_A012_C031_SDR_20190726_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/BO_A012_C031_SDR_20190726_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "83C65C90-270C-4490-9C69-F51FE03D7F06",
     "accessibilityLabel": "Seals",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/SE_A016_C009_SDR_20190717_SDR_2K_AVC.mov"
-    },
     "name": "Seals",
-    "pointsOfInterest": {
-      "0": "Cape Fur Seals off the coast of Cape Peninsula, South Africa"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Cape Fur Seals off the coast of Cape Peninsula, South Africa" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/SE_A016_C009_SDR_20190717_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/SE_A016_C009_SDR_20190717_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/SE_A016_C009_SDR_20190717_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "87060EC2-D006-4102-98CC-3005C68BB343",
     "accessibilityLabel": "South Africa to North Asia",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A351_C001_v06_SDR_PS_20180725_SDR_2K_AVC.mov"
-    },
     "name": "South Africa to North Asia",
     "pointsOfInterest": {
       "0": "Traveling northeast over the Ethiopian Highlands",
@@ -1457,14 +1525,16 @@
       "400": "Traveling north over Kazakhstan",
       "450": "Over the Altai Mountains moving into Mongolia"
     },
-    "type": "space"
+    "type": "space",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A351_C001_v06_SDR_PS_20180725_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A351_C001_v06_SDR_PS_20180725_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A351_C001_v06_SDR_PS_20180725_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "7719B48A-2005-4011-9280-2F64EEC6FD91",
     "accessibilityLabel": "Southern California to Baja",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A114_C001_0305OT_v10_SDR_FINAL_22062018_SDR_2K_AVC.mov"
-    },
     "name": "Northern California to Baja",
     "pointsOfInterest": {
       "0": "Over the Pacific Ocean heading toward the United States",
@@ -1479,38 +1549,40 @@
       "290": "The Pacific Ocean off the coast of Mexico and Guatemalao"
     },
     "type": "space",
-    "timeOfDay": "day"
+    "timeOfDay": "day",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A114_C001_0305OT_v10_SDR_FINAL_22062018_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A114_C001_0305OT_v10_SDR_FINAL_22062018_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A114_C001_0305OT_v10_SDR_FINAL_22062018_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "149E7795-DBDA-4F5D-B39A-14712F841118",
     "accessibilityLabel": "Tahiti Waves",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/g201_TH_803_A001_8_SDR_20191031_SDR_2K_AVC.mov"
-    },
     "name": "Tahiti Waves 1",
-    "pointsOfInterest": {
-      "0": "Waves breaking on the shores of Tahiti"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Waves breaking on the shores of Tahiti" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/g201_TH_803_A001_8_SDR_20191031_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/g201_TH_803_A001_8_SDR_20191031_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/g201_TH_803_A001_8_SDR_20191031_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "8C31B06F-91A4-4F7C-93ED-56146D7F48B9",
     "accessibilityLabel": "Tahiti Waves",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/g201_TH_804_A001_8_SDR_20191031_SDR_2K_AVC.mov"
-    },
     "name": "Tahiti Waves 2",
-    "pointsOfInterest": {
-      "0": "Waves breaking on the shores of Tahiti"
-    },
-    "type": "underwater"
+    "pointsOfInterest": { "0": "Waves breaking on the shores of Tahiti" },
+    "type": "underwater",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/g201_TH_804_A001_8_SDR_20191031_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/g201_TH_804_A001_8_SDR_20191031_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/g201_TH_804_A001_8_SDR_20191031_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "63C042F0-90EF-4A95-B7CC-CC9A64BF8421",
     "accessibilityLabel": "West Africa to the Alps",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/comp_A001_C004_1207W5_v23_SDR_FINAL_20180706_SDR_2K_AVC.mov"
-    },
     "name": "West Africa to the Alps",
     "pointsOfInterest": {
       "0": "The Canary Islands Atlantic Ocean and coast of Africa",
@@ -1524,72 +1596,32 @@
       "220": "Moving northeast over the Alps"
     },
     "type": "space",
-    "timeOfDay": "day"
+    "timeOfDay": "day",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/comp_A001_C004_1207W5_v23_SDR_FINAL_20180706_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A001_C004_1207W5_v23_SDR_FINAL_20180706_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/comp_A001_C004_1207W5_v23_SDR_FINAL_20180706_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E5799A24-1949-4E66-A17B-B5EB05F28C5D",
     "accessibilityLabel": "Yosemite",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/Y004_C015_SDR_2K_AVC.mov"
-    },
     "name": "Half Dome and Nevada Fall",
     "pointsOfInterest": {
       "0": "",
       "124": "Passing by Half Dome and approaching Nevada Fall in Yosemite National Park",
       "146": "Half Dome and Nevada Fall in Yosemite National Park, United States"
     },
-    "type": "landscape"
-  },
-  {
-    "id": "81CA5ACD-E682-4D8B-A948-0F147EB6ED4F",
-    "accessibilityLabel": "Yosemite",
+    "type": "landscape",
     "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/Y003_C009_SDR_2K_AVC.mov"
-    },
-    "name": "Merced Peak",
-    "pointsOfInterest": {
-      "0": "Over Yosemite National Park, United States",
-      "93": "Traveling toward Merced Peak in Yosemite National Park, United States",
-      "130": "Merced Peak in Yosemite National Park, United States",
-      "221": "Passing by Merced Peak in Yosemite National Park, United States",
-      "244": "Traveling over Yosemite National Park, United States"
-    },
-    "type": "landscape"
-  },
-  {
-    "id": "DAD82DCE-F3AE-4AEC-8A79-1694D412FC0A",
-    "accessibilityLabel": "Yosemite",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/Y009_C015_SDR_2K_AVC.mov"
-    },
-    "name": "Tuolumne Meadows",
-    "pointsOfInterest": {
-      "0": "Passing over Tuolumne Meadows in Yosemite National Park, United States"
-    },
-    "type": "landscape"
-  },
-  {
-    "id": "8D04D70F-738B-441D-8D43-AF46B2BF8062",
-    "accessibilityLabel": "Yosemite",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/Y011_C008_SDR_2K_AVC.mov"
-    },
-    "name": "Matthes Crest",
-    "pointsOfInterest": {
-      "0": "Traveling toward Matthes Crest in Yosemite National Park, United States",
-      "75": "",
-      "124": "Flying through Matthes Crest in Yosemite National Park, United States",
-      "215": "Flying over Matthes Crest in Yosemite National Park, United States",
-      "396": "Moving toward Tuolumne Meadows in Yosemite National Park, United States"
-    },
-    "type": "landscape"
+      "H2641080p": "https://sylvan.apple.com/Videos/Y004_C015_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/Y004_C015_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/Y004_C015_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E487C6EF-B3FB-427B-A2BE-8CBA60F902F0",
     "accessibilityLabel": "Yosemite",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/Y005_C003_SDR_2K_AVC.mov"
-    },
     "name": "Yosemite 1",
     "pointsOfInterest": {
       "0": "Over Yosemite National Park in the United States",
@@ -1599,29 +1631,46 @@
       "255": "Nevada and Illilouette Falls in Yosemite National Park, United States",
       "285": ""
     },
-    "type": "landscape"
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/Y005_C003_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/Y005_C003_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/Y005_C003_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "E540DEE6-4C40-42C8-9CCC-D4CB0FAD7D7B",
     "accessibilityLabel": "Yosemite",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/Y002_C013_SDR_2K_AVC.mov"
-    },
     "name": "Yosemite 2",
+    "pointsOfInterest": { "0": "", "70": "Approaching Half Dome in Yosemite National Park, United States", "87": "", "210": "" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/Y002_C013_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/Y002_C013_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/Y002_C013_SDR_4K_HEVC.mov"
+    }
+  },
+  {
+    "id": "81CA5ACD-E682-4D8B-A948-0F147EB6ED4F",
+    "accessibilityLabel": "Yosemite",
+    "name": "Merced Peak",
     "pointsOfInterest": {
-      "0": "",
-      "70": "Approaching Half Dome in Yosemite National Park, United States",
-      "87": "",
-      "210": ""
+      "0": "Over Yosemite National Park, United States",
+      "93": "Traveling toward Merced Peak in Yosemite National Park, United States",
+      "130": "Merced Peak in Yosemite National Park, United States",
+      "221": "Passing by Merced Peak in Yosemite National Park, United States",
+      "244": "Traveling over Yosemite National Park, United States"
     },
-    "type": "landscape"
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/Y003_C009_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/Y003_C009_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/Y003_C009_SDR_4K_HEVC.mov"
+    }
   },
   {
     "id": "4109D42A-D717-46A7-A9A2-FE53A82B25C0",
     "accessibilityLabel": "Yosemite",
-    "src": {
-      "H2641080p": "https://sylvan.apple.com/Videos/Y011_C001_SDR_2K_AVC.mov"
-    },
     "name": "Yosemite 3",
     "pointsOfInterest": {
       "0": "Traveling toward Bridalveil Fall and El Capitan in Yosemite National Park",
@@ -1632,6 +1681,41 @@
       "470": "Traveling past Half Dome in Yosemite Valley, United States",
       "585": "Traveling east over Yosemite Valley, United States"
     },
-    "type": "landscape"
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/Y011_C001_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/Y011_C001_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/Y011_C001_SDR_4K_HEVC.mov"
+    }
+  },
+  {
+    "id": "DAD82DCE-F3AE-4AEC-8A79-1694D412FC0A",
+    "accessibilityLabel": "Yosemite",
+    "name": "Tuolumne Meadows",
+    "pointsOfInterest": { "0": "Passing over Tuolumne Meadows in Yosemite National Park, United States" },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/Y009_C015_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/Y009_C015_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/Y009_C015_SDR_4K_HEVC.mov"
+    }
+  },
+  {
+    "id": "8D04D70F-738B-441D-8D43-AF46B2BF8062",
+    "accessibilityLabel": "Yosemite",
+    "name": "Matthes Crest",
+    "pointsOfInterest": {
+      "0": "Traveling toward Matthes Crest in Yosemite National Park, United States",
+      "75": "",
+      "124": "Flying through Matthes Crest in Yosemite National Park, United States",
+      "215": "Flying over Matthes Crest in Yosemite National Park, United States",
+      "396": "Moving toward Tuolumne Meadows in Yosemite National Park, United States"
+    },
+    "type": "landscape",
+    "src": {
+      "H2641080p": "https://sylvan.apple.com/Videos/Y011_C008_SDR_2K_AVC.mov",
+      "H2651080p": "https://sylvan.apple.com/Aerials/2x/Videos/Y011_C008_SDR_2K_HEVC.mov",
+      "H2654k": "https://sylvan.apple.com/Aerials/2x/Videos/Y011_C008_SDR_4K_HEVC.mov"
+    }
   }
 ]

--- a/web/config.html
+++ b/web/config.html
@@ -558,10 +558,10 @@
                                                                  style="width: 5%; display: inline; margin-top: 2%; padding: 0;"
                                                                  onchange="updateSetting('textColor', 'text')">
                     <hr>
-                    <label for="textSize">Random Change Speed</label><input class="w3-input" id="randomSpeed"
+                    <label for="textSize">Change random position every </label><input class="w3-input" id="randomSpeed"
                                                                             type="number" step="1"
                                                                             style="width: 10%; display: inline; margin-top: 2%"
-                                                                            onchange="updateSetting('randomSpeed', 'number')">
+                                                                            onchange="updateSetting('randomSpeed', 'number')"> seconds
 
                 </div>
             </div>

--- a/web/config.html
+++ b/web/config.html
@@ -100,7 +100,7 @@
                     <select id="videoFileType" onclick="updateSetting('videoFileType','select')">
                         <option value="H2641080p">H.264 1080p</option>
                         <option value="H2651080p">H.265 1080p</option>
-                        <option value="H2654K">H.265 4K</option>
+                        <option value="H2654k">H.265 4K</option>
                     </select>
                     <br>
                     <i class="w3-small" style="padding-left: 4%;">H.265 videos may not play on all systems</i>

--- a/web/config.html
+++ b/web/config.html
@@ -383,7 +383,7 @@
             </div>
             <div class="w3-display-container">
                 <video autoplay loop controls id="videoPlayer" class="w3-display-middle"
-                       style=" width: 90%; padding-top: 55%; display: inline"></video>
+                       style=" width: 90%; padding-top: 55%; display: inline; z-index: 100;"></video>
                 <div id="videoSettings"></div>
                 <div id="videoInfo" class="videoInfo"></div>
             </div>

--- a/web/config.html
+++ b/web/config.html
@@ -95,13 +95,25 @@
                     <i class="w3-small" style="padding-left: 4%">When this option is enabled Aerial will avoid playing
                         the
                         most recently played videos</i>
+                    <hr>
+                    <label for="videoFileType">Video Resolution: </label>
+                    <select id="videoFileType" onclick="updateSetting('videoFileType','select')">
+                        <option value="H2641080p">H.264 1080p</option>
+                        <option value="H2651080p">H.265 1080p</option>
+                        <option value="H2654K">H.265 4K</option>
+                    </select>
+                    <br>
+                    <i class="w3-small" style="padding-left: 4%;">H.265 videos may not play on all systems</i>
+                    <span style="padding-left: 8%; margin-top: -3%; position: absolute;">
+                        <button class="w3-button w3-white w3-border w3-border-green w3-round-large" onclick="document.getElementById('videoResolutionExplain').style.display='block'">More Info</button>
+                    </span>
                     <br><br>
                     <label for="fillMode">Fill Mode: </label>
                     <select id="fillMode" onclick="updateSetting('fillMode','select')">
                         <option value="stretch">Stretch</option>
                         <option value="crop">Crop</option>
                     </select>
-                    <br><br>
+                    <hr>
                     <label for="transitionType"> Transition Type: </label>
                     <select id="transitionType" onclick="updateSetting('transitionType','select')">
                         <option value="dissolve">Dissolve</option>
@@ -125,7 +137,7 @@
                     <br>
                     <input type="range" min="500" max="4000" value="2000" step="100" id="videoTransitionLength"
                            class="slider" onchange="updateSetting('videoTransitionLength','slider')">
-                    <br><br>
+                    <hr>
                     <input type="checkbox" id="skipVideosWithKey" class="w3-check"
                            onclick="updateSetting('skipVideosWithKey','check')">
                     <label for="skipVideosWithKey">Use a key to skip videos</label>
@@ -397,7 +409,8 @@
                            onclick="positionSelect(this)"><label></label>
                      Random
                     </span>
-                    <div class="w3-container" id="textWidthContainer" style="display: none; position: absolute; left: 29.5%; margin-top: -1.8%">
+                    <div class="w3-container" id="textWidthContainer"
+                         style="display: none; position: absolute; left: 29.5%; margin-top: -1.8%">
                         <br>
                         <label for="textWidthSelect">Max Width:</label>
                         <select id="textWidthSelect">
@@ -780,6 +793,52 @@
             <br>
             <button class="w3-button w3-white w3-border w3-border-blue w3-round-large"
                     onclick="document.getElementById('needsLocation').style.display='none';">
+                Done
+            </button>
+            </p>
+        </div>
+    </div>
+</div>
+<div id="videoResolutionExplain" class="w3-modal">
+    <div class="w3-modal-content">
+        <div class="w3-container w3-white w3-medium">
+            <span onclick="document.getElementById('videoResolutionExplain').style.display='none'"
+                  class="w3-button w3-display-topright">&times;</span>
+            <br>
+            <h2>Video Resolutions</h2>
+            <p>
+                Apple hosts three different files for each video in two different formats and resolutions. They are:
+                <ul>
+                    <li>H.264</li>
+                    <ul>
+                        <li>1080p (1920x1080)</li>
+                    </ul>
+                    <li>H.265 (HVEC)</li>
+                    <ul>
+                        <li>1080p (1920x1080)</li>
+                        <li>4K (3840x2160)</li>
+                    </ul>
+                </ul>
+            </p>
+            <div style="width: 30%;margin-left: 70%; margin-top: -15%">
+                <video width="100%" autoplay controls src="https://sylvan.apple.com/Aerials/2x/Videos/G010_C026_UHD_SDR_v02_2K_HEVC.mov"></video>
+                <p class="w3-small" style="margin-top: -2%">An H.256 video</p>
+            </div>
+            <p>
+                H.264 is a universal standard that can be played on all devices.
+                It has a less compression, meaning videos will be larger, but potentially play back smoother.
+                Apple only hosts these videos in 1080p.
+            </p><p>
+                H.265 (HEVC) is a newer standards that isn't universally adopted, not all computers can play H.265 videos.
+                It has smaller more compression, meaning videos will be smaller.
+                Additionally, Apple hosts both 1080p and 4K H.265 videos.
+            </p><p>
+                If your computer supports H.265, use it. If it does not, or if you are having problems playing H.265 videos, switch back to H.264.
+                If you can see the video above, your computer can play H.265 videos.
+                When using the cache, you will need to delete and re-download your videos if you change types to see an effect.
+            </p>
+            <button class="w3-button w3-white w3-border w3-border-blue w3-round-large"
+                    onclick="document.getElementById('videoResolutionExplain').style.display='none';">
                 Done
             </button>
             </p>

--- a/web/config.html
+++ b/web/config.html
@@ -55,7 +55,7 @@
                 <div class="w3-display-container cardContent" style="padding: 2%">
                     <label for="startAfter">Start Aerial After</label>
                     <input style="width: 10%; display: inline !important;" class="w3-input" type="number"
-                           id="startAfter" onchange="updateSetting('startAfter','number')">
+                           id="startAfter" onchange="updateSetting('startAfter','number')" min=0>
                     minutes
                     <br><br>
                     <input type="checkbox" id="blankScreen" class="w3-check"

--- a/web/config.js
+++ b/web/config.js
@@ -619,7 +619,7 @@ function selectVideo(index) {
     if (index > -1) {
         downloadedVideos = electron.store.get("downloadedVideos");
         document.getElementById("videoList-" + index).className += " w3-deep-orange";
-        let videoSRC = videos[index].src.H2641080p;
+        let videoSRC = videos[index].src[electron.store.get('videoFileType')];
         if (downloadedVideos.includes(videos[index].id)) {
             videoSRC = `${electron.store.get('cachePath')}/${videos[index].id}.mov`;
         }

--- a/web/config.js
+++ b/web/config.js
@@ -13,7 +13,7 @@ function displaySettings() {
     for (let i = 0; i < checked.length; i++) {
         $(`#${checked[i]}`).prop('checked', electron.store.get(checked[i]));
     }
-    let numTxt = ["sunrise", "sunset", "textFont", "textSize", "textColor", "startAfter", "blankAfter", "fps", "latitude", "longitude", "randomSpeed", "skipKey", "transitionType", "fillMode", "globalShortcutModifier1", "globalShortcutModifier2", "globalShortcutKey", "lockAfterRunAfter"];
+    let numTxt = ["sunrise", "sunset", "textFont", "textSize", "textColor", "startAfter", "blankAfter", "fps", "latitude", "longitude", "randomSpeed", "skipKey", "transitionType", "fillMode", "globalShortcutModifier1", "globalShortcutModifier2", "globalShortcutKey", "lockAfterRunAfter", "videoFileType"];
     for (let i = 0; i < numTxt.length; i++) {
         $(`#${numTxt[i]}`).val(electron.store.get(numTxt[i]));
     }

--- a/web/screensaver.js
+++ b/web/screensaver.js
@@ -84,7 +84,7 @@ function prepVideo(videoContainer, callback) {
             });
             videoInfo = videos[index];
             downloadedVideos = electron.store.get("downloadedVideos");
-            videoSRC = videoInfo.src.H2641080p;
+            videoSRC = videoInfo.src[electron.store.get('videoFileType')];
             if (downloadedVideos.includes(videoInfo.id)) {
                 videoSRC = `${electron.store.get('cachePath')}/${videoInfo.id}.mov`;
             }

--- a/web/screensaver.js
+++ b/web/screensaver.js
@@ -48,7 +48,7 @@ function videoError(event) {
     if (event.srcElement === containers[currentPlayer]) {
         setTimeout(() => {
             if (event.srcElement.currentTime === 0) {
-                console.log('VIDEO PLAYBACK ERROR', event.target.error.message, event);
+                console.error('VIDEO PLAYBACK ERROR', event.target.error.message, event);
                 if (previousErrorId !== currentlyPlaying) {
                     newVideo();
                 }
@@ -57,7 +57,7 @@ function videoError(event) {
             }
         }, 500 * numErrors);
     } else {
-        console.log("Error in Pre-Player");
+        console.warn("Error in Pre-Player");
     }
 }
 
@@ -667,9 +667,8 @@ function switchRandomText() {
     let newLoc = false;
     let c = 0;
     do {
-        console.log("switching random text");
         if (c > 100) {
-            console.log("random overload - nowhere to go");
+            console.error("random overload - nowhere to go");
             break;
         }
         newLoc = displayText.positionList[randomInt(0, displayText.positionList.length - 1)];

--- a/web/screensaver.js
+++ b/web/screensaver.js
@@ -199,8 +199,10 @@ function drawDynamicText() {
 
 let transitionLength = electron.store.get('videoTransitionLength');
 let transitionPercent = 1;
+let transitionSource = "";
 
 function fadeVideoOut(time) {
+    transitionSource = "fadeout";
     if (time > 0) {
         transitionTimeout = setTimeout(fadeVideoOut, 16, time - 16);
     }
@@ -208,6 +210,9 @@ function fadeVideoOut(time) {
     if (transitionPercent <= 0) {
         transitionPercent = 0;
         clearTimeout(transitionTimeout);
+        setTimeout(() => {
+            transitionSource = ""
+        }, 1000);
     } else if (transitionPercent >= 1) {
         transitionPercent = 1;
     }
@@ -221,7 +226,7 @@ function fadeTextOut(time) {
 }
 
 function fadeVideoIn(time) {
-    if(time === transitionLength){
+    if (time === transitionLength) {
         if (transitionSettings.type === "random") {
             randomType = true;
             transitionSettings.type = transitionTypes[randomInt(0, transitionTypes.length)];
@@ -298,151 +303,158 @@ function drawVideo() {
     ctx1.globalCompositeOperation = "source-over";
     ctx1.globalAlpha = 1;
     if (transitionPercent < 1) {
-        let gradient, maxBound, rad;
-        switch (transitionSettings.type) {
-            case "dissolve":
-                if (containers[currentPlayer].paused) {
-                    ctx1.fillStyle = `rgb(0, 0, 0)`;
-                    ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
-                    ctx1.fill();
-                } else {
-                    drawImage(ctx1, containers[currentPlayer]);
-                }
-                ctx1.globalCompositeOperation = "destination-out";
-                ctx1.fillStyle = `rgba(0,0,0,${transitionPercent})`;
-                ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
-                ctx1.fill();
-                ctx1.globalCompositeOperation = "destination-over";
-                drawImage(ctx1, containers[prePlayer]);
-                break;
-            case "dipToBlack":
-                if (transitionPercent <= .5) {
-                    drawImage(ctx1, containers[currentPlayer]);
+        if (transitionSource === "fadeout") {
+            drawImage(ctx1, containers[currentPlayer]);
+            ctx1.fillStyle = `rgba(0,0,0,${1 - transitionPercent})`;
+            ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
+            ctx1.fill();
+        } else {
+            let gradient, maxBound, rad;
+            switch (transitionSettings.type) {
+                case "dissolve":
+                    if (containers[currentPlayer].paused) {
+                        ctx1.fillStyle = `rgb(0, 0, 0)`;
+                        ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
+                        ctx1.fill();
+                    } else {
+                        drawImage(ctx1, containers[currentPlayer]);
+                    }
                     ctx1.globalCompositeOperation = "destination-out";
-                    ctx1.fillStyle = `rgba(0,0,0,${transitionPercent * 2})`;
-                    ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
-                    ctx1.fill();
-                    ctx1.globalCompositeOperation = "destination-over";
-                    ctx1.fillStyle = `rgb(0, 0, 0)`;
-                    ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
-                    ctx1.fill();
-                } else {
-                    ctx1.fillStyle = `rgb(0, 0, 0)`;
-                    ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
-                    ctx1.fill();
-                    ctx1.globalCompositeOperation = "destination-out";
-                    ctx1.fillStyle = `rgba(0,0,0,${(transitionPercent - .5) * 2})`;
+                    ctx1.fillStyle = `rgba(0,0,0,${transitionPercent})`;
                     ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
                     ctx1.fill();
                     ctx1.globalCompositeOperation = "destination-over";
                     drawImage(ctx1, containers[prePlayer]);
-                }
-                break;
-            case"fade":
-                drawImage(ctx1, containers[prePlayer]);
-                ctx1.globalCompositeOperation = "destination-out";
-                switch (transitionSettings.direction) {
-                    case "left":
-                        gradient = ctx1.createLinearGradient(0, window.innerHeight / 2, window.innerWidth, window.innerHeight / 2);
-                        break;
-                    case "right":
-                        gradient = ctx1.createLinearGradient(window.innerWidth, window.innerHeight / 2, 0, window.innerHeight / 2);
-                        break;
-                    case "top":
-                        gradient = ctx1.createLinearGradient(window.innerWidth / 2, 0, window.innerWidth / 2, window.innerHeight);
-                        break;
-                    case "bottom":
-                        gradient = ctx1.createLinearGradient(window.innerWidth / 2, window.innerHeight, window.innerWidth / 2, 0);
-                        break;
-                    case "top-left":
-                        gradient = ctx1.createLinearGradient(0, 0, window.innerWidth, window.innerHeight);
-                        break;
-                    case"top-right":
-                        gradient = ctx1.createLinearGradient(window.innerWidth, 0, 0, window.innerHeight);
-                        break;
-                    case"bottom-left":
-                        gradient = ctx1.createLinearGradient(0, window.innerHeight, window.innerWidth, 0);
-                        break;
-                    case"bottom-right":
-                        gradient = ctx1.createLinearGradient(window.innerWidth, window.innerHeight, 0, 0,);
-                        break;
-                }
-                gradient.addColorStop(transitionPercent, "rgba(0,0,0,0)");
-                gradient.addColorStop(transitionPercent + .15 > 1 ? 1 : transitionPercent + .15, `rgba(0, 0, 0, 1)`);
-                ctx1.fillStyle = gradient;
-                ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
-                ctx1.fill();
-                ctx1.globalCompositeOperation = "destination-over";
-                drawImage(ctx1, containers[currentPlayer]);
-                break;
-            case "wipe":
-                drawImage(ctx1, containers[prePlayer]);
-                ctx1.globalCompositeOperation = "destination-in";
-                ctx1.globalAlpha = 1;
-                ctx1.fillStyle = "#000000";
-                switch (transitionSettings.direction) {
-                    case "left":
-                        ctx1.rect(0, 0, window.innerWidth * transitionPercent, window.innerHeight);
-                        break;
-                    case "right":
-                        ctx1.rect(window.innerWidth - (window.innerWidth * transitionPercent), 0, window.innerWidth, window.innerHeight);
-                        break;
-                    case "top":
-                        ctx1.rect(0, 0, window.innerWidth, window.innerHeight * transitionPercent);
-                        break;
-                    case "bottom":
-                        ctx1.rect(0, window.innerHeight - (window.innerHeight * transitionPercent), window.innerWidth, window.innerHeight);
-                        break;
-                }
-
-                ctx1.fill();
-                ctx1.globalCompositeOperation = "destination-over";
-                drawImage(ctx1, containers[currentPlayer]);
-                break;
-            case "circle":
-                if (transitionSettings.direction === 'normal') {
+                    break;
+                case "dipToBlack":
+                    if (transitionPercent <= .5) {
+                        drawImage(ctx1, containers[currentPlayer]);
+                        ctx1.globalCompositeOperation = "destination-out";
+                        ctx1.fillStyle = `rgba(0,0,0,${transitionPercent * 2})`;
+                        ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
+                        ctx1.fill();
+                        ctx1.globalCompositeOperation = "destination-over";
+                        ctx1.fillStyle = `rgb(0, 0, 0)`;
+                        ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
+                        ctx1.fill();
+                    } else {
+                        ctx1.fillStyle = `rgb(0, 0, 0)`;
+                        ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
+                        ctx1.fill();
+                        ctx1.globalCompositeOperation = "destination-out";
+                        ctx1.fillStyle = `rgba(0,0,0,${(transitionPercent - .5) * 2})`;
+                        ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
+                        ctx1.fill();
+                        ctx1.globalCompositeOperation = "destination-over";
+                        drawImage(ctx1, containers[prePlayer]);
+                    }
+                    break;
+                case"fade":
                     drawImage(ctx1, containers[prePlayer]);
-                    maxBound = window.innerWidth > window.innerHeight ? window.innerWidth : window.innerHeight;
-                    rad = maxBound * (transitionPercent > 1 ? 1 : transitionPercent < 0 ? 0 : transitionPercent);
-                    ctx1.fillStyle = "#000000";
+                    ctx1.globalCompositeOperation = "destination-out";
+                    switch (transitionSettings.direction) {
+                        case "left":
+                            gradient = ctx1.createLinearGradient(0, window.innerHeight / 2, window.innerWidth, window.innerHeight / 2);
+                            break;
+                        case "right":
+                            gradient = ctx1.createLinearGradient(window.innerWidth, window.innerHeight / 2, 0, window.innerHeight / 2);
+                            break;
+                        case "top":
+                            gradient = ctx1.createLinearGradient(window.innerWidth / 2, 0, window.innerWidth / 2, window.innerHeight);
+                            break;
+                        case "bottom":
+                            gradient = ctx1.createLinearGradient(window.innerWidth / 2, window.innerHeight, window.innerWidth / 2, 0);
+                            break;
+                        case "top-left":
+                            gradient = ctx1.createLinearGradient(0, 0, window.innerWidth, window.innerHeight);
+                            break;
+                        case"top-right":
+                            gradient = ctx1.createLinearGradient(window.innerWidth, 0, 0, window.innerHeight);
+                            break;
+                        case"bottom-left":
+                            gradient = ctx1.createLinearGradient(0, window.innerHeight, window.innerWidth, 0);
+                            break;
+                        case"bottom-right":
+                            gradient = ctx1.createLinearGradient(window.innerWidth, window.innerHeight, 0, 0,);
+                            break;
+                    }
+                    gradient.addColorStop(transitionPercent, "rgba(0,0,0,0)");
+                    gradient.addColorStop(transitionPercent + .15 > 1 ? 1 : transitionPercent + .15, `rgba(0, 0, 0, 1)`);
+                    ctx1.fillStyle = gradient;
+                    ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
+                    ctx1.fill();
+                    ctx1.globalCompositeOperation = "destination-over";
+                    drawImage(ctx1, containers[currentPlayer]);
+                    break;
+                case "wipe":
+                    drawImage(ctx1, containers[prePlayer]);
                     ctx1.globalCompositeOperation = "destination-in";
-                    ctx1.arc(window.innerWidth / 2, window.innerHeight / 2, rad, 0, Math.PI * 2);
-                    ctx1.fill();
-
-                    ctx1.globalCompositeOperation = "destination-over";
-                    drawImage(ctx1, containers[currentPlayer]);
-                } else {
-                    drawImage(ctx1, containers[prePlayer]);
-                    maxBound = window.innerWidth > window.innerHeight ? window.innerWidth : window.innerHeight;
-                    rad = maxBound * (1 - (transitionPercent > 1 ? 1 : transitionPercent < 0 ? 0 : transitionPercent));
+                    ctx1.globalAlpha = 1;
                     ctx1.fillStyle = "#000000";
-                    ctx1.globalCompositeOperation = "destination-out";
-                    ctx1.arc(window.innerWidth / 2, window.innerHeight / 2, rad, 0, Math.PI * 2);
+                    switch (transitionSettings.direction) {
+                        case "left":
+                            ctx1.rect(0, 0, window.innerWidth * transitionPercent, window.innerHeight);
+                            break;
+                        case "right":
+                            ctx1.rect(window.innerWidth - (window.innerWidth * transitionPercent), 0, window.innerWidth, window.innerHeight);
+                            break;
+                        case "top":
+                            ctx1.rect(0, 0, window.innerWidth, window.innerHeight * transitionPercent);
+                            break;
+                        case "bottom":
+                            ctx1.rect(0, window.innerHeight - (window.innerHeight * transitionPercent), window.innerWidth, window.innerHeight);
+                            break;
+                    }
+
                     ctx1.fill();
                     ctx1.globalCompositeOperation = "destination-over";
                     drawImage(ctx1, containers[currentPlayer]);
-                }
-                break;
-            case "fadeCircle" :
-                drawImage(ctx1, containers[prePlayer]);
-                ctx1.globalCompositeOperation = "destination-out";
-                maxBound = window.innerWidth > window.innerHeight ? window.innerWidth : window.innerHeight;
-                switch (transitionSettings.direction) {
-                    case "reverse":
-                        gradient = ctx1.createRadialGradient(window.innerWidth / 2, window.innerHeight / 2, maxBound, window.innerWidth / 2, window.innerHeight / 2, 0);
-                        break;
-                    default:
-                        gradient = ctx1.createRadialGradient(window.innerWidth / 2, window.innerHeight / 2, 0, window.innerWidth / 2, window.innerHeight / 2, maxBound);
-                        break;
-                }
-                gradient.addColorStop(transitionPercent, "rgba(0,0,0,0)");
-                gradient.addColorStop(transitionPercent + .05 > 1 ? 1 : transitionPercent + .05, `rgba(0, 0, 0, 1)`);
-                ctx1.fillStyle = gradient;
-                ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
-                ctx1.fill();
-                ctx1.globalCompositeOperation = "destination-over";
-                drawImage(ctx1, containers[currentPlayer]);
-                break;
+                    break;
+                case "circle":
+                    if (transitionSettings.direction === 'normal') {
+                        drawImage(ctx1, containers[prePlayer]);
+                        maxBound = window.innerWidth > window.innerHeight ? window.innerWidth : window.innerHeight;
+                        rad = maxBound * (transitionPercent > 1 ? 1 : transitionPercent < 0 ? 0 : transitionPercent);
+                        ctx1.fillStyle = "#000000";
+                        ctx1.globalCompositeOperation = "destination-in";
+                        ctx1.arc(window.innerWidth / 2, window.innerHeight / 2, rad, 0, Math.PI * 2);
+                        ctx1.fill();
+
+                        ctx1.globalCompositeOperation = "destination-over";
+                        drawImage(ctx1, containers[currentPlayer]);
+                    } else {
+                        drawImage(ctx1, containers[prePlayer]);
+                        maxBound = window.innerWidth > window.innerHeight ? window.innerWidth : window.innerHeight;
+                        rad = maxBound * (1 - (transitionPercent > 1 ? 1 : transitionPercent < 0 ? 0 : transitionPercent));
+                        ctx1.fillStyle = "#000000";
+                        ctx1.globalCompositeOperation = "destination-out";
+                        ctx1.arc(window.innerWidth / 2, window.innerHeight / 2, rad, 0, Math.PI * 2);
+                        ctx1.fill();
+                        ctx1.globalCompositeOperation = "destination-over";
+                        drawImage(ctx1, containers[currentPlayer]);
+                    }
+                    break;
+                case "fadeCircle" :
+                    drawImage(ctx1, containers[prePlayer]);
+                    ctx1.globalCompositeOperation = "destination-out";
+                    maxBound = window.innerWidth > window.innerHeight ? window.innerWidth : window.innerHeight;
+                    switch (transitionSettings.direction) {
+                        case "reverse":
+                            gradient = ctx1.createRadialGradient(window.innerWidth / 2, window.innerHeight / 2, maxBound, window.innerWidth / 2, window.innerHeight / 2, 0);
+                            break;
+                        default:
+                            gradient = ctx1.createRadialGradient(window.innerWidth / 2, window.innerHeight / 2, 0, window.innerWidth / 2, window.innerHeight / 2, maxBound);
+                            break;
+                    }
+                    gradient.addColorStop(transitionPercent, "rgba(0,0,0,0)");
+                    gradient.addColorStop(transitionPercent + .05 > 1 ? 1 : transitionPercent + .05, `rgba(0, 0, 0, 1)`);
+                    ctx1.fillStyle = gradient;
+                    ctx1.rect(0, 0, window.innerWidth, window.innerHeight);
+                    ctx1.fill();
+                    ctx1.globalCompositeOperation = "destination-over";
+                    drawImage(ctx1, containers[currentPlayer]);
+                    break;
+            }
         }
     } else {
         drawImage(ctx1, containers[currentPlayer]);
@@ -647,7 +659,7 @@ for (let i = 0; i < displayText.random.length; i++) {
 }
 if (random) {
     displayText.random.currentLocation = "none";
-    setTimeout(switchRandomText,750);
+    setTimeout(switchRandomText, 750);
     let randomInterval = setInterval(switchRandomText, electron.store.get('randomSpeed') * 1000);
 }
 
@@ -699,7 +711,7 @@ electron.ipcRenderer.on('blankTheScreen', () => {
     setTimeout(() => {
         video.src = "";
         video2.src = "";
-    }, transitionLength);
+    }, transitionLength + 750);
 });
 
 electron.ipcRenderer.on('screenNumber', (number) => {

--- a/web/screensaver.js
+++ b/web/screensaver.js
@@ -639,7 +639,6 @@ function createContentLine(contentLine, position, line) {
     return html;
 }
 
-//Random is broken. Remove this when it is fixed.
 let random = false;
 for (let i = 0; i < displayText.random.length; i++) {
     if (displayText.random[i].type !== "none") {
@@ -648,7 +647,7 @@ for (let i = 0; i < displayText.random.length; i++) {
 }
 if (random) {
     displayText.random.currentLocation = "none";
-    switchRandomText();
+    setTimeout(switchRandomText,750);
     let randomInterval = setInterval(switchRandomText, electron.store.get('randomSpeed') * 1000);
 }
 
@@ -656,8 +655,9 @@ function switchRandomText() {
     let newLoc = false;
     let c = 0;
     do {
+        console.log("switching random text");
         if (c > 100) {
-            console.log("overload");
+            console.log("random overload - nowhere to go");
             break;
         }
         newLoc = displayText.positionList[randomInt(0, displayText.positionList.length - 1)];


### PR DESCRIPTION
## This new release includes the following:
* H.265 Video Support (#17)
    * Aerial now supports Apple's H.265 videos in both 1080p (for lower file sizes) and 4K
* There are now two ways to have Aerial avoid launching when playing other videos:
    * Use `aerial.scr` to install using the system screensaver API
    * Or configure Aerial to run as an administrator
* Minor bug fixes
    *  Random text position works
    * Start after time can be set to 0
    * Temp folder in video cache won't cause errors